### PR TITLE
refactor to use `NamedTuple` outputs

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,11 +116,12 @@ end
 
     @test stale_explicit_imports_nonrecursive(TestModA.SubModB.TestModA.TestModC,
                                               "TestModC.jl") ==
-          [:exported_c, :exported_d]
+          [(; name=:exported_c), (; name=:exported_d)]
 
     # Recursive version
     lookup = Dict(stale_explicit_imports(TestModA, "TestModA.jl"))
-    @test lookup[TestModA.SubModB.TestModA.TestModC] == [:exported_c, :exported_d]
+    @test lookup[TestModA.SubModB.TestModA.TestModC] ==
+          [(; name=:exported_c), (; name=:exported_d)]
     @test isempty(lookup[TestModA])
 
     # Printing
@@ -134,7 +135,7 @@ end
 
     # Recursion
     nested = @test_logs (:warn, r"stale") explicit_imports(TestModA, "TestModA.jl")
-    @test nested isa Vector{Pair{Module,Vector{Pair{Symbol,Module}}}}
+    @test nested isa Vector{Pair{Module,Vector{@NamedTuple{name::Symbol,source::Module}}}}
     @test TestModA in first.(nested)
     @test TestModA.SubModB in first.(nested)
     @test TestModA.SubModB.TestModA in first.(nested)
@@ -244,7 +245,8 @@ end
         @test_logs log @test explicit_imports(DynMod, "DynMod.jl") ==
                              [DynMod => nothing, DynMod.Hidden => nothing]
         @test_logs log @test explicit_imports(DynMod, "DynMod.jl"; strict=false) ==
-                             [DynMod => [:print_explicit_imports => ExplicitImports],
+                             [DynMod => [(; name=:print_explicit_imports,
+                                          source=ExplicitImports)],
                               # Wrong! Missing explicit export
                               DynMod.Hidden => []]
 
@@ -252,7 +254,7 @@ end
 
         @test_logs log @test explicit_imports_nonrecursive(DynMod, "DynMod.jl";
                                                            strict=false) ==
-                             [:print_explicit_imports => ExplicitImports]
+                             [(; name=:print_explicit_imports, source=ExplicitImports)]
         @test_logs log @test stale_explicit_imports(DynMod, "DynMod.jl") ==
                              [DynMod => nothing,
                               DynMod.Hidden => nothing]


### PR DESCRIPTION
I want to get this in before v1.0 is tagged, so we can add richer outputs without breaking things. Xref https://github.com/ericphanson/ExplicitImports.jl/issues/4.