### PR TITLE
Add `show_locations` kwarg to print the location of the name being used from global namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ using JuliaSyntax: JuliaSyntax
 
 Note: the `WARNING` is more or less harmless; the way this package is written, it will happen any time there is a clash, even if that clash is not realized in your code. I cannot figure out how to suppress it.
 
+You can also pass `show_locations=true` for more details:
+
+````julia
+julia> print_explicit_imports(ExplicitImports; show_locations=true)
+Module ExplicitImports is relying on implicit imports for 6 names. These could be explicitly imported as follows:
+
+```julia
+using AbstractTrees: AbstractTrees # used at /Users/eph/ExplicitImports/src/parse_utilities.jl:51:10
+using AbstractTrees: Leaves # used at /Users/eph/ExplicitImports/src/get_names_used.jl:225:17
+using AbstractTrees: TreeCursor # used at /Users/eph/ExplicitImports/src/parse_utilities.jl:107:18
+using AbstractTrees: children # used at /Users/eph/ExplicitImports/src/get_names_used.jl:161:26
+using AbstractTrees: nodevalue # used at /Users/eph/ExplicitImports/src/parse_utilities.jl:96:34
+using JuliaSyntax: JuliaSyntax # used at /Users/eph/ExplicitImports/src/parse_utilities.jl:103:15
+```
+````
+
+Note the paths of course will differ depending on the location of the code on your system.
+
+This can be handy for debugging; if you find that in fact ExplicitImports thinks a local variable is a global from another module, please file an issue and include the code snippet!
+
 ## Limitations
 
 ### Some tricky scoping situations are not handled correctly

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -1,6 +1,6 @@
 struct ImplicitImportsException <: Exception
     mod::Module
-    names::Vector{@NamedTuple{name::Symbol,source::Module}}
+    names::Vector{@NamedTuple{name::Symbol,source::Module,location::String}}
 end
 
 function Base.showerror(io::IO, e::ImplicitImportsException)
@@ -13,7 +13,7 @@ end
 
 struct StaleImportsException <: Exception
     mod::Module
-    names::Vector{@NamedTuple{name::Symbol}}
+    names::Vector{@NamedTuple{name::Symbol,location::String}}
 end
 
 function Base.showerror(io::IO, e::StaleImportsException)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,6 +203,12 @@ end
     @test contains(str,
                    "However, Main.TestModA.SubModB.TestModA.TestModC has stale explicit imports for these unused names")
 
+    # test `show_locations=true`
+    str = @test_logs sprint(io -> print_explicit_imports(io, TestModA, "TestModA.jl";
+                                                         show_locations=true))
+    @test contains(str, "using .Exporter3: Exporter3 # used at TestModA.jl:")
+    @test contains(str, "(imported at TestModC.jl:")
+
     # `warn_stale=false` does something (also still no logs)
     str_no_warn = @test_logs sprint(io -> print_explicit_imports(io, TestModA,
                                                                  "TestModA.jl";

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,16 @@ function restrict_to_module(df, mod)
                   :module_path => ByRow(ms -> all(Base.splat(isequal), zip(ms, mod_path))))
 end
 
+function drop_location(nt::@NamedTuple{name::Symbol,source::Module,location::String})
+    return (; nt.name, nt.source)
+end
+function drop_location(nt::@NamedTuple{name::Symbol,location::String})
+    return (; nt.name)
+end
+drop_location(::Nothing) = nothing
+drop_location(v::Vector) = drop_location.(v)
+drop_location(p::Pair) = first(p) => drop_location(last(p))
+
 include("Exporter.jl")
 include("TestModA.jl")
 include("test_mods.jl")
@@ -154,12 +164,12 @@ end
     @test_logs explicit_imports_nonrecursive(TestModA.SubModB.TestModA.TestModC,
                                              "TestModC.jl"; warn_stale=false)
 
-    @test stale_explicit_imports_nonrecursive(TestModA.SubModB.TestModA.TestModC,
-                                              "TestModC.jl") ==
+    @test drop_location(stale_explicit_imports_nonrecursive(TestModA.SubModB.TestModA.TestModC,
+                                                            "TestModC.jl")) ==
           [(; name=:exported_c), (; name=:exported_d)]
 
     # Recursive version
-    lookup = Dict(stale_explicit_imports(TestModA, "TestModA.jl"))
+    lookup = Dict(drop_location(stale_explicit_imports(TestModA, "TestModA.jl")))
     @test lookup[TestModA.SubModB.TestModA.TestModC] ==
           [(; name=:exported_c), (; name=:exported_d)]
     @test isempty(lookup[TestModA])
@@ -175,7 +185,8 @@ end
 
     # Recursion
     nested = @test_logs (:warn, r"stale") explicit_imports(TestModA, "TestModA.jl")
-    @test nested isa Vector{Pair{Module,Vector{@NamedTuple{name::Symbol,source::Module}}}}
+    @test nested isa Vector{Pair{Module,
+                                 Vector{@NamedTuple{name::Symbol,source::Module,location::String}}}}
     @test TestModA in first.(nested)
     @test TestModA.SubModB in first.(nested)
     @test TestModA.SubModB.TestModA in first.(nested)
@@ -262,10 +273,17 @@ end
                                                                        "TestModC.jl")
 
     # make sure ignored names don't show up in error
-    e = StaleImportsException(TestModA.SubModB.TestModA.TestModC, [(; name=:exported_c)])
-    @test_throws e check_no_stale_explicit_imports(TestModA.SubModB.TestModA.TestModC,
-                                                   "TestModC.jl",
-                                                   ignore=(:exported_d,))
+    e = try
+        check_no_stale_explicit_imports(TestModA.SubModB.TestModA.TestModC,
+                                        "TestModC.jl";
+                                        ignore=(:exported_d,))
+        @test false # should error before this
+    catch e
+        e
+    end
+    str = sprint(Base.showerror, e)
+    @test contains(str, "exported_c")
+    @test !contains(str, "exported_d")
 
     # ignore works:
     @test check_no_stale_explicit_imports(TestModA.SubModB.TestModA.TestModC,
@@ -288,9 +306,10 @@ end
     @testset "Tainted modules" begin
         log = (:warn, r"Dynamic")
 
-        @test_logs log @test explicit_imports(DynMod, "DynMod.jl") ==
+        @test_logs log @test drop_location(explicit_imports(DynMod, "DynMod.jl")) ==
                              [DynMod => nothing, DynMod.Hidden => nothing]
-        @test_logs log @test explicit_imports(DynMod, "DynMod.jl"; strict=false) ==
+        @test_logs log @test drop_location(explicit_imports(DynMod, "DynMod.jl";
+                                                            strict=false)) ==
                              [DynMod => [(; name=:print_explicit_imports,
                                           source=ExplicitImports)],
                               # Wrong! Missing explicit export
@@ -298,8 +317,9 @@ end
 
         @test_logs log @test explicit_imports_nonrecursive(DynMod, "DynMod.jl") === nothing
 
-        @test_logs log @test explicit_imports_nonrecursive(DynMod, "DynMod.jl";
-                                                           strict=false) ==
+        @test_logs log @test drop_location(explicit_imports_nonrecursive(DynMod,
+                                                                         "DynMod.jl";
+                                                                         strict=false)) ==
                              [(; name=:print_explicit_imports, source=ExplicitImports)]
         @test_logs log @test stale_explicit_imports(DynMod, "DynMod.jl") ==
                              [DynMod => nothing,


### PR DESCRIPTION
closes #4 

Can be handy for debugging and MWEs