### PR TITLE
handle macronames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/get_names_used.jl
+++ b/src/get_names_used.jl
@@ -229,10 +229,10 @@ function analyze_all_names(file; debug=false)
             continue
         end
 
-        # if we don't find any identifiers in a module, I think it's OK to mark it as
+        # if we don't find any identifiers (or macro names) in a module, I think it's OK to mark it as
         # "not-seen"? Otherwise we need to analyze every leaf, not just the identifiers
         # and that sounds slow. Seems like a very rare edge case to have no identifiers...
-        kind(leaf) == K"Identifier" || continue
+        kind(leaf) in (K"Identifier", K"MacroName") || continue
 
         # Skip quoted identifiers
         # This won't necessarily catch if they are part of a big quoted block,

--- a/test/Exporter.jl
+++ b/test/Exporter.jl
@@ -1,6 +1,6 @@
 module Exporter
 
-export exported_a, exported_b, exported_c, x, exported_d
+export exported_a, exported_b, exported_c, x, exported_d, @mac
 
 exported_a() = "hi"
 exported_b() = "hi-b"
@@ -10,6 +10,9 @@ exported_d() = "hi-d"
 un_exported() = "bye"
 
 x = 2
+
+macro mac(args...)
+end
 
 end # Exporter
 

--- a/test/TestModA.jl
+++ b/test/TestModA.jl
@@ -16,6 +16,8 @@ g() = exported_a()
 
 g2() = un_exported()
 
+@mac
+
 x = 1
 
 function func()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,7 +91,8 @@ end
 
 @testset "ExplicitImports.jl" begin
     @test using_statement.(explicit_imports_nonrecursive(TestModA, "TestModA.jl")) ==
-          ["using .Exporter: Exporter", "using .Exporter: exported_a",
+          ["using .Exporter: Exporter", "using .Exporter: @mac",
+           "using .Exporter: exported_a",
            "using .Exporter2: Exporter2", "using .Exporter3: Exporter3"]
 
     per_usage_info, _ = analyze_all_names("TestModA.jl")


### PR DESCRIPTION
closes #15 

On this branch I get:
````julia
julia> using ExplicitImports, Lux

julia> print_explicit_imports(Lux)
Module Lux is relying on implicit imports for 54 names. These could be explicitly imported as follows:

```julia
using Adapt: Adapt
using Adapt: adapt
using ArrayInterface: ArrayInterface
using ChainRulesCore: ChainRulesCore
using ChainRulesCore: AbstractZero
using ChainRulesCore: HasReverseMode
using ChainRulesCore: NoTangent
using ChainRulesCore: ProjectTo
using ChainRulesCore: RuleConfig
using ChainRulesCore: ZeroTangent
using ConcreteStructs: ConcreteStructs
using ConcreteStructs: @concrete
using Functors: Functors
using Functors: fmap
using GPUArraysCore: GPUArraysCore
using LinearAlgebra: LinearAlgebra
using LuxCore: LuxCore
using LuxDeviceUtils: LuxDeviceUtils
using LuxDeviceUtils: cpu_device
using LuxDeviceUtils: get_device
using LuxDeviceUtils: gpu_device
using LuxLib: LuxLib
using LuxLib: alpha_dropout
using LuxLib: batchnorm
using LuxLib: dropout
using LuxLib: groupnorm
using LuxLib: instancenorm
using LuxLib: layernorm
using Markdown: Markdown
using NNlib: NNlib
using NNlib: DenseConvDims
using NNlib: PoolDims
using NNlib: batched_mul
using NNlib: conv
using NNlib: maxpool
using NNlib: meanpool
using NNlib: pixel_shuffle
using NNlib: sigmoid_fast
using NNlib: tanh_fast
using NNlib: ∇conv_data
using Random: Random
using Random: AbstractRNG
using Reexport: Reexport
using Reexport: @reexport
using Setfield: Setfield
using Setfield: @set!
using SparseArrays: SparseArrays
using Statistics: Statistics
using Statistics: mean
using WeightInitializers: WeightInitializers
using WeightInitializers: glorot_uniform
using WeightInitializers: ones32
using WeightInitializers: randn32
using WeightInitializers: zeros32
```

Additionally, Lux has stale explicit imports for these unused names:
- AbstractLuxDevice
- AbstractLuxDeviceAdaptor
- AbstractLuxGPUDevice
- inputsize
- setup
- testmode
- trainmode
- update_state

Module Lux.Experimental is relying on implicit imports for 15 names. These could be explicitly imported as follows:

```julia
using ADTypes: ADTypes
using ConcreteStructs: ConcreteStructs
using Functors: Functors
using LuxCore: LuxCore
using LuxDeviceUtils: LuxDeviceUtils
using LuxDeviceUtils: gpu_device
using MacroTools: MacroTools
using MacroTools: block
using MacroTools: combinedef
using MacroTools: splitdef
using Markdown: Markdown
using Optimisers: Optimisers
using Random: Random
using Random: AbstractRNG
using Setfield: Setfield
```

Module Lux.Training is relying on implicit imports for 3 names. These could be explicitly imported as follows:

```julia
using ADTypes: ADTypes
using Reexport: Reexport
using Reexport: @reexport
```
````

so it looks like it is correctly pulling in `@concrete`.