### PR TITLE
detect string macro usages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -15,9 +15,10 @@ DataFrames = "1.6"
 JuliaSyntax = "0.4.8"
 LinearAlgebra = "<0.0.1, 1"
 Logging = "<0.0.1, 1"
-Pkg = "<0.0.1, 1"
+Markdown = "<0.0.1, 1"
 TOML = "<0.0.1, 1"
 Test = "<0.0.1, 1"
+Pkg = "<0.0.1, 1"
 julia = "1.7"
 
 [extras]
@@ -25,8 +26,9 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "DataFrames", "LinearAlgebra", "Logging", "Pkg", "Test"]
+test = ["Aqua", "DataFrames", "LinearAlgebra", "Logging", "Markdown", "Pkg", "Test"]

--- a/src/get_names_used.jl
+++ b/src/get_names_used.jl
@@ -232,7 +232,7 @@ function analyze_all_names(file; debug=false)
         # if we don't find any identifiers (or macro names) in a module, I think it's OK to mark it as
         # "not-seen"? Otherwise we need to analyze every leaf, not just the identifiers
         # and that sounds slow. Seems like a very rare edge case to have no identifiers...
-        kind(leaf) in (K"Identifier", K"MacroName") || continue
+        kind(leaf) in (K"Identifier", K"MacroName", K"StringMacroName") || continue
 
         # Skip quoted identifiers
         # This won't necessarily catch if they are part of a big quoted block,

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -19,3 +19,25 @@ function pinthreads_mpi(::Val{:numa}, rank::Integer, nranks::Integer;
 end
 
 end
+
+module Foo20
+
+using Markdown
+
+@doc doc"""
+testing docs
+"""
+function testing_docstr end
+
+end
+
+module Bar20
+
+using Markdown: @doc_str
+
+@doc doc"""
+testing docs
+"""
+function testing_docstr end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using Aqua
 using Logging
 using AbstractTrees
 using ExplicitImports: is_function_definition_arg, SyntaxNodeWrapper, get_val
-using TestPkg
+using TestPkg, Markdown
 
 # DataFrames version of `filter_to_module`
 function restrict_to_module(df, mod)
@@ -50,6 +50,14 @@ if VERSION > v"1.9-"
                               (; name=:DataFrame, source=DataFrames),
                               (; name=:groupby, source=DataFrames)]
     end
+end
+
+@testset "string macros (#20)" begin
+    foo = drop_location(explicit_imports_nonrecursive(Foo20, "examples.jl"))
+    @test foo == [(; name=:Markdown, source=Markdown),
+                  (; name=Symbol("@doc_str"), source=Markdown)]
+    bar = explicit_imports_nonrecursive(Bar20, "examples.jl")
+    @test isempty(bar)
 end
 
 @testset "TestModArgs" begin


### PR DESCRIPTION
closes https://github.com/ericphanson/ExplicitImports.jl/issues/20

Note: I expect we are still not correctly identifying function arguments correctly as local variables in macro or string macro definitions, i.e. #8 for macros / string macros. But at least that should be much rarer, so seems less urgent.