### PR TITLE
add script functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,13 +18,25 @@ print_stale_explicit_imports
 stale_explicit_imports
 ```
 
-## Usage in testing
+## Checks to use in testing
 
 ExplicitImports.jl provides two functions which can be used to regression test that there is no reliance on implicit imports or stale explicit imports:
 
 ```@docs
 check_no_implicit_imports
 check_no_stale_explicit_imports
+```
+
+## Usage with scripts (such as `runtests.jl`)
+
+We also provide a helper function to analyze scripts (rather than modules).
+If you are using a module in your script (e.g. if your script starts with `module`),
+then use the ordinary `print_explicit_imports` function instead.
+This functionality is somewhat experimental and attempts to filter the relevant names in `Main`
+to those used in your script.
+
+```@docs
+print_explicit_imports_script
 ```
 
 ## Non-recursive variants

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ include("test_mods.jl")
 include("DynMod.jl")
 include("TestModArgs.jl")
 include("examples.jl")
+include("script.jl")
 
 # package extension support needs Julia 1.9+
 if VERSION > v"1.9-"
@@ -60,6 +61,7 @@ end
     @test contains(str, "stale explicit imports for these unused names")
     @test contains(str, "- qr")
 end
+
 @testset "string macros (#20)" begin
     foo = drop_location(explicit_imports_nonrecursive(Foo20, "examples.jl"))
     @test foo == [(; name=:Markdown, source=Markdown),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,14 @@ if VERSION > v"1.9-"
     end
 end
 
+@testset "scripts" begin
+    str = sprint(print_explicit_imports_script, "script.jl")
+    @test contains(str, "Script `script.jl`")
+    @test contains(str, "relying on implicit imports for 1 name")
+    @test contains(str, "using LinearAlgebra: norm")
+    @test contains(str, "stale explicit imports for these unused names")
+    @test contains(str, "- qr")
+end
 @testset "string macros (#20)" begin
     foo = drop_location(explicit_imports_nonrecursive(Foo20, "examples.jl"))
     @test foo == [(; name=:Markdown, source=Markdown),
@@ -145,7 +153,7 @@ end
            "using .TestModA: f"]
 
     mod_path = module_path(TestModA.SubModB)
-    @test mod_path == [:SubModB, :TestModA]
+    @test mod_path == [:SubModB, :TestModA, :Main]
     sub_df = restrict_to_module(df, TestModA.SubModB)
 
     h = only(subset(sub_df, :name => ByRow(==(:h))))
@@ -167,7 +175,7 @@ end
 
     # starts from innermost
     @test module_path(TestModA.SubModB.TestModA.TestModC) ==
-          [:TestModC, :TestModA, :SubModB, :TestModA]
+          [:TestModC, :TestModA, :SubModB, :TestModA, :Main]
 
     from_outer_file = @test_logs (:warn, r"stale") using_statement.(explicit_imports_nonrecursive(TestModA.SubModB.TestModA.TestModC,
                                                                                                   "TestModA.jl"))
@@ -229,7 +237,7 @@ end
     @test contains(str, "Module Main.TestModA is relying on implicit imports")
     @test contains(str, "using .Exporter: exported_a")
     @test contains(str,
-                   "However, Main.TestModA.SubModB.TestModA.TestModC has stale explicit imports for these unused names")
+                   "However, module Main.TestModA.SubModB.TestModA.TestModC has stale explicit imports for these unused names")
 
     # test `show_locations=true`
     str = @test_logs sprint(io -> print_explicit_imports(io, TestModA, "TestModA.jl";

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,0 +1,5 @@
+using LinearAlgebra
+using LinearAlgebra: qr # unnecessary
+
+x = rand(5, 5)
+norm(x)


### PR DESCRIPTION
closes https://github.com/ericphanson/ExplicitImports.jl/issues/19

````julia
julia> print_explicit_imports_script("script.jl")
Script `script.jl` is relying on implicit imports for 1 names. These could be explicitly imported as follows:

```julia
using LinearAlgebra: norm
```

Additionally, script `script.jl` has stale explicit imports for these unused names:
- qr
````

I think this should also include `using LinearAlgebra: LinearAlgebra`, but that doesn't work, since `which(Main, :LinearAlgebra) === Main` (whereas I think it should be `LinearAlgebra). I filed https://github.com/JuliaLang/julia/issues/53576 for that.