### PR TITLE
Print a module that exports the name rather than the module that defines the name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -57,7 +57,7 @@ end
 """
     explicit_imports(mod::Module, file=pathof(mod); skip=(mod, Base, Core), warn_stale=true, strict=true)
 
-Returns a nested structure providing information about explicit import statements one could make for each submodule of `mod`. This information is structured as a collection of pairs, where the keys are the submodules of `mod` (including `mod` itself), and the values are `NamedTuple`s, with at least the keys `name`, `source`, and `location`, showing which names are being used implicitly, which modules they came from, and the location of those usages. Additional keys may be added to the `NamedTuple`'s in the future in non-breaking releases of ExplicitImports.jl.
+Returns a nested structure providing information about explicit import statements one could make for each submodule of `mod`. This information is structured as a collection of pairs, where the keys are the submodules of `mod` (including `mod` itself), and the values are `NamedTuple`s, with at least the keys `name`, `source`, `exporters`, and `location`, showing which names are being used implicitly, which modules they were defined in, which modules they were exported from, and the location of those usages. Additional keys may be added to the `NamedTuple`'s in the future in non-breaking releases of ExplicitImports.jl.
 
 ## Arguments
 

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -1,6 +1,7 @@
 struct ImplicitImportsException <: Exception
     mod::Module
-    names::Vector{@NamedTuple{name::Symbol,source::Module,location::String}}
+    names::Vector{@NamedTuple{name::Symbol,source::Module,exporters::Vector{Module},
+                              location::String}}
 end
 
 function Base.showerror(io::IO, e::ImplicitImportsException)

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,3 +1,4 @@
+# https://github.com/ericphanson/ExplicitImports.jl/issues/1
 module ThreadPinning
 
 using LinearAlgebra
@@ -20,6 +21,7 @@ end
 
 end
 
+# https://github.com/ericphanson/ExplicitImports.jl/issues/20
 module Foo20
 
 using Markdown
@@ -41,7 +43,6 @@ testing docs
 function testing_docstr end
 
 end
-
 
 # https://github.com/ericphanson/ExplicitImports.jl/issues/24
 module Mod24

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -41,3 +41,11 @@ testing docs
 function testing_docstr end
 
 end
+
+
+# https://github.com/ericphanson/ExplicitImports.jl/issues/24
+module Mod24
+using ..Exporter2
+
+exported_a
+end


### PR DESCRIPTION
closes #24

On this branch I get:
````julia
julia> print_explicit_imports(MixedModels)
WARNING: both Distributions and BSplineKit export "support"; uses of it in module MixedModels must be qualified
Module MixedModels is relying on implicit imports for 162 names. These could be explicitly imported as follows:

```julia
using Arrow: Arrow
using BSplineKit: BSplineKit
using BSplineKit: BSplineOrder
using BSplineKit: Natural
using BSplineKit: Derivative
using BSplineKit: SplineInterpolation
using BSplineKit: interpolate
using DataAPI: DataAPI
using Distributions: Distributions
using GLM: Bernoulli
using GLM: Binomial
using Distributions: Chisq
using Distributions: Distribution
using GLM: Gamma
using GLM: InverseGaussian
using GLM: Normal
using GLM: Poisson
using Distributions: ccdf
using Distributions: estimate
using GLM: GLM
using GLM: GeneralizedLinearModel
using GLM: IdentityLink
using GLM: InverseLink
using GLM: LinearModel
using GLM: LogLink
using GLM: LogitLink
using GLM: ProbitLink
using GLM: SqrtLink
using GLM: glm
using JSON3: JSON3
using LinearAlgebra: LinearAlgebra
using LinearAlgebra: Adjoint
using LinearAlgebra: BLAS
using LinearAlgebra: ColumnNorm
using LinearAlgebra: Diagonal
using LinearAlgebra: Hermitian
using LinearAlgebra: I
using LinearAlgebra: LAPACK
using LinearAlgebra: LowerTriangular
using LinearAlgebra: SVD
using LinearAlgebra: SymTridiagonal
using LinearAlgebra: Symmetric
using LinearAlgebra: UpperTriangular
using LinearAlgebra: cond
using LinearAlgebra: diag
using LinearAlgebra: diagind
using LinearAlgebra: dot
using LinearAlgebra: eigen
using LinearAlgebra: isdiag
using LinearAlgebra: ldiv!
using LinearAlgebra: lmul!
using LinearAlgebra: logdet
using LinearAlgebra: mul!
using LinearAlgebra: norm
using LinearAlgebra: normalize
using LinearAlgebra: normalize!
using LinearAlgebra: qr
using LinearAlgebra: rank
using LinearAlgebra: rdiv!
using LinearAlgebra: rmul!
using LinearAlgebra: svd
using LinearAlgebra: tr
using LinearAlgebra: tril!
using Markdown: Markdown
using NLopt: NLopt
using NLopt: ftol_abs
using NLopt: ftol_rel
using NLopt: initial_step
using NLopt: maxtime
using NLopt: xtol_abs
using NLopt: xtol_rel
using PooledArrays: PooledArrays
using PooledArrays: PooledArray
using PrecompileTools: PrecompileTools
using PrecompileTools: @compile_workload
using PrecompileTools: @setup_workload
using ProgressMeter: ProgressMeter
using ProgressMeter: Progress
using ProgressMeter: ProgressUnknown
using ProgressMeter: finish!
using ProgressMeter: next!
using Random: Random
using Random: AbstractRNG
using Random: randn!
using SparseArrays: SparseArrays
using SparseArrays: SparseMatrixCSC
using SparseArrays: SparseVector
using SparseArrays: dropzeros!
using SparseArrays: nnz
using SparseArrays: nonzeros
using SparseArrays: nzrange
using SparseArrays: rowvals
using SparseArrays: sparse
using StaticArrays: StaticArrays
using StaticArrays: SVector
using Statistics: Statistics
using StatsBase: mean
using StatsBase: quantile
using StatsBase: std
using StatsAPI: StatsAPI
using StatsBase: aic
using StatsBase: aicc
using StatsBase: bic
using StatsBase: coef
using StatsModels: coefnames
using StatsBase: coeftable
using StatsBase: confint
using StatsBase: deviance
using StatsBase: dof
using StatsBase: dof_residual
using StatsBase: fit
using StatsBase: fit!
using StatsBase: fitted
using StatsBase: isfitted
using StatsBase: islinear
using StatsBase: leverage
using StatsBase: loglikelihood
using StatsBase: meanresponse
using StatsModels: modelmatrix
using StatsBase: nobs
using StatsBase: predict
using StatsBase: r2
using StatsBase: residuals
using StatsModels: response
using StatsBase: responsename
using StatsBase: stderror
using StatsBase: vcov
using StatsBase: weights
using StatsBase: StatsBase
using StatsBase: CoefTable
using StatsBase: model_response
using StatsBase: summarystats
using StatsModels: StatsModels
using StatsModels: @formula
using StatsModels: AbstractContrasts
using StatsModels: AbstractTerm
using StatsModels: CategoricalTerm
using StatsModels: ConstantTerm
using StatsModels: DummyCoding
using StatsModels: EffectsCoding
using StatsModels: FormulaTerm
using StatsModels: FunctionTerm
using StatsModels: HelmertCoding
using StatsModels: HypothesisCoding
using StatsModels: InteractionTerm
using StatsModels: InterceptTerm
using StatsModels: MatrixTerm
using StatsModels: SeqDiffCoding
using StatsModels: Term
using StatsModels: apply_schema
using StatsModels: drop_term
using StatsModels: formula
using StatsModels: modelcols
using StatsModels: term
using StructTypes: StructTypes
using Tables: Tables
using Tables: columntable
using TypedTables: rows
using TypedTables: TypedTables
using TypedTables: DictTable
using TypedTables: FlexTable
using TypedTables: Table
```

Additionally, module MixedModels has stale explicit imports for these unused names:
- BlasReal
- copytri!
- dataset
- datasets
- linkfun
````

In particular, note the
```julia
using StaticArrays: StaticArrays
using StaticArrays: SVector
```
and
```julia
using BSplineKit: BSplineKit
using BSplineKit: BSplineOrder
using BSplineKit: Natural
using BSplineKit: Derivative
using BSplineKit: SplineInterpolation
using BSplineKit: interpolate
```

which fixes the two issues @palday called out in https://github.com/JuliaStats/MixedModels.jl/pull/748