### PR TITLE
format `using` statements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/README.md
+++ b/README.md
@@ -42,15 +42,11 @@ julia> using ExplicitImports
 
 julia> print_explicit_imports(ExplicitImports)
 WARNING: both JuliaSyntax and Base export "parse"; uses of it in module ExplicitImports must be qualified
-Module ExplicitImports is relying on implicit imports for 6 names. These could be explicitly imported as follows:
+Module ExplicitImports is relying on implicit imports for 7 names. These could be explicitly imported as follows:
 
 ```julia
-using AbstractTrees: AbstractTrees
-using AbstractTrees: Leaves
-using AbstractTrees: TreeCursor
-using AbstractTrees: children
-using AbstractTrees: nodevalue
-using JuliaSyntax: JuliaSyntax
+using AbstractTrees: AbstractTrees, Leaves, TreeCursor, children, nodevalue
+using JuliaSyntax: JuliaSyntax, @K_str
 ```
 
 ````


### PR DESCRIPTION
I prefer this format a bit more:
````julia
julia> print_explicit_imports(MixedModels)
Module MixedModels is relying on implicit imports for 162 names. These could be explicitly imported as follows:

```julia
using Arrow: Arrow
using BSplineKit: BSplineKit, BSplineOrder, Derivative, Natural,
                  SplineInterpolation, interpolate
using DataAPI: DataAPI
using Distributions: Distributions, Chisq, Distribution, ccdf, estimate
using GLM: GLM, Bernoulli, Binomial, Gamma, GeneralizedLinearModel,
           IdentityLink, InverseGaussian, InverseLink, LinearModel, LogLink,
           LogitLink, Normal, Poisson, ProbitLink, SqrtLink, glm
using JSON3: JSON3
using LinearAlgebra: LinearAlgebra, Adjoint, BLAS, ColumnNorm, Diagonal,
                     Hermitian, I, LAPACK, LowerTriangular, SVD,
                     SymTridiagonal, Symmetric, UpperTriangular, cond, diag,
                     diagind, dot, eigen, isdiag, ldiv!, lmul!, logdet, mul!,
                     norm, normalize, normalize!, qr, rank, rdiv!, rmul!, svd,
                     tr, tril!
using Markdown: Markdown
using NLopt: NLopt, ftol_abs, ftol_rel, initial_step, maxtime, xtol_abs,
             xtol_rel
using PooledArrays: PooledArrays, PooledArray
using PrecompileTools: PrecompileTools, @compile_workload, @setup_workload
using ProgressMeter: ProgressMeter, Progress, ProgressUnknown, finish!, next!
using Random: Random, AbstractRNG, randn!
using SparseArrays: SparseArrays, SparseMatrixCSC, SparseVector, dropzeros!,
                    nnz, nonzeros, nzrange, rowvals, sparse
using StaticArrays: StaticArrays, SVector
using Statistics: Statistics
using StatsAPI: StatsAPI
using StatsBase: StatsBase, CoefTable, aic, aicc, bic, coef, coeftable, confint,
                 deviance, dof, dof_residual, fit, fit!, fitted, isfitted,
                 islinear, leverage, loglikelihood, mean, meanresponse,
                 model_response, nobs, predict, quantile, r2, residuals,
                 responsename, std, stderror, summarystats, vcov, weights
using StatsModels: StatsModels, @formula, AbstractContrasts, AbstractTerm,
                   CategoricalTerm, ConstantTerm, DummyCoding, EffectsCoding,
                   FormulaTerm, FunctionTerm, HelmertCoding, HypothesisCoding,
                   InteractionTerm, InterceptTerm, MatrixTerm, SeqDiffCoding,
                   Term, apply_schema, coefnames, drop_term, formula,
                   modelcols, modelmatrix, response, term
using StructTypes: StructTypes
using Tables: Tables, columntable
using TypedTables: TypedTables, DictTable, FlexTable, Table, rows
```

Additionally, module MixedModels has stale explicit imports for these unused names:
- BlasReal
- copytri!
- dataset
- datasets
- linkfun

````

However, something similar to the 1-per-line way can still be obtained:

````julia
julia> print_explicit_imports(MixedModels; linewidth=0)
Module MixedModels is relying on implicit imports for 162 names. These could be explicitly imported as follows:

```julia
using Arrow: Arrow
using BSplineKit: BSplineKit,
                  BSplineOrder,
                  Derivative,
                  Natural,
                  SplineInterpolation,
                  interpolate
using DataAPI: DataAPI
using Distributions: Distributions,
                     Chisq,
                     Distribution,
                     ccdf,
                     estimate
using GLM: GLM,
           Bernoulli,
           Binomial,
           Gamma,
           GeneralizedLinearModel,
           IdentityLink,
           InverseGaussian,
           InverseLink,
           LinearModel,
           LogLink,
           LogitLink,
           Normal,
           Poisson,
           ProbitLink,
           SqrtLink,
           glm
using JSON3: JSON3
using LinearAlgebra: LinearAlgebra,
                     Adjoint,
                     BLAS,
                     ColumnNorm,
                     Diagonal,
                     Hermitian,
                     I,
                     LAPACK,
                     LowerTriangular,
                     SVD,
                     SymTridiagonal,
                     Symmetric,
                     UpperTriangular,
                     cond,
                     diag,
                     diagind,
                     dot,
                     eigen,
                     isdiag,
                     ldiv!,
                     lmul!,
                     logdet,
                     mul!,
                     norm,
                     normalize,
                     normalize!,
                     qr,
                     rank,
                     rdiv!,
                     rmul!,
                     svd,
                     tr,
                     tril!
using Markdown: Markdown
using NLopt: NLopt,
             ftol_abs,
             ftol_rel,
             initial_step,
             maxtime,
             xtol_abs,
             xtol_rel
using PooledArrays: PooledArrays,
                    PooledArray
using PrecompileTools: PrecompileTools,
                       @compile_workload,
                       @setup_workload
using ProgressMeter: ProgressMeter,
                     Progress,
                     ProgressUnknown,
                     finish!,
                     next!
using Random: Random,
              AbstractRNG,
              randn!
using SparseArrays: SparseArrays,
                    SparseMatrixCSC,
                    SparseVector,
                    dropzeros!,
                    nnz,
                    nonzeros,
                    nzrange,
                    rowvals,
                    sparse
using StaticArrays: StaticArrays,
                    SVector
using Statistics: Statistics
using StatsAPI: StatsAPI
using StatsBase: StatsBase,
                 CoefTable,
                 aic,
                 aicc,
                 bic,
                 coef,
                 coeftable,
                 confint,
                 deviance,
                 dof,
                 dof_residual,
                 fit,
                 fit!,
                 fitted,
                 isfitted,
                 islinear,
                 leverage,
                 loglikelihood,
                 mean,
                 meanresponse,
                 model_response,
                 nobs,
                 predict,
                 quantile,
                 r2,
                 residuals,
                 responsename,
                 std,
                 stderror,
                 summarystats,
                 vcov,
                 weights
using StatsModels: StatsModels,
                   @formula,
                   AbstractContrasts,
                   AbstractTerm,
                   CategoricalTerm,
                   ConstantTerm,
                   DummyCoding,
                   EffectsCoding,
                   FormulaTerm,
                   FunctionTerm,
                   HelmertCoding,
                   HypothesisCoding,
                   InteractionTerm,
                   InterceptTerm,
                   MatrixTerm,
                   SeqDiffCoding,
                   Term,
                   apply_schema,
                   coefnames,
                   drop_term,
                   formula,
                   modelcols,
                   modelmatrix,
                   response,
                   term
using StructTypes: StructTypes
using Tables: Tables,
              columntable
using TypedTables: TypedTables,
                   DictTable,
                   FlexTable,
                   Table,
                   rows
```

Additionally, module MixedModels has stale explicit imports for these unused names:
- BlasReal
- copytri!
- dataset
- datasets
- linkfun
````
