### PR TITLE
Provide functionality to detect "improper qualified access"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,17 +21,16 @@ jobs:
         version:
           - '1.7' # earliest supported version
           - '1' # current release
+          - 'beta'
           - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      # Using `juliaup` over `setup-julia` so we can access beta versions easier
+      - uses: julia-actions/install-juliaup@v1
         with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          julia-version: ${{ matrix.version }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.4.3"
+version = "1.4.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.4.4"
+version = "1.5.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ See the [API docs](https://ericphanson.github.io/ExplicitImports.jl/dev/api/) fo
 - functionality to help convert implicit imports to explicit exports
 - functionality to warn about "stale" (unused) explicit imports
 - functionality to add to package tests to ensure all imports continue to be explicit (and non-stale)
+- functionality to detect "improper" qualified access to names, such as accessing `LinearAlgebra.map` instead of `Base.map` (since `map` is owned by Base, and just happens to be available in the `LinearAlgebra` namespace)
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ There are various takes on _how problematic_ this issue is, to what extent this 
 
 Personally, I don't think this is always a huge issue, and that it's basically fine for packages to use implicit imports if that is their preferred style and they understand the risk. But I do think this issue is somewhat a "hole" in the semver system as it applies to Julia packages, and I wanted to create some tooling to make it easier to mitigate the issue for package authors who would prefer to not rely on implicit imports.
 
+## Ways ExplicitImports.jl can and cannot help
+
+As mentioned, there are two ways to avoid implicit imports: by using explicit imports such as `using X: foo`, or by qualifying names (`X.foo`).
+
+ExplicitImports.jl was initially designed to help make explicit imports more ergonomic, by providing functionality to convert implicit imports into explicit ones (e.g. `print_explicit_imports`), and by providing testing tools to keep a codebase free of implicit imports and without stale explicit imports. There are two missing features here still: checking the explicitly imported names are public in the module they are being imported from (e.g. avoid `using X: _internal_foo`), and a weaker condition, checking that they are owned by the module they are being imported from (e.g. avoid `using LinearAlgebra: map`, since `map` comes from Base).
+
+Since v1.5, ExplicitImports.jl has also gained functionality to make using qualifying names more ergonomic. One pitfall of qualified accesses like `X.foo` is that `foo` may be internal to `X` or may be owned by another module (the same issues faced by explicit imports). The function `improper_qualified_accesses` can detect the latter case.
+
 ## Implementation status
 
 ExplicitImports.jl has been used successfully on several codebases, but I would still not describe it as fully mature. That said, it should be ready for use; please file issues if problems arise.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ using AbstractTrees: AbstractTrees, Leaves, TreeCursor, children, nodevalue
 using JuliaSyntax: JuliaSyntax, @K_str
 ```
 
-Additionally, module ExplicitImports accesses names from non-parent modules:
+Additionally, module ExplicitImports accesses names from non-owner modules:
 - `parent` has owner AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
 
 ````
@@ -76,7 +76,7 @@ using AbstractTrees: nodevalue # used at /Users/eph/ExplicitImports/src/parse_ut
 using JuliaSyntax: JuliaSyntax # used at /Users/eph/ExplicitImports/src/parse_utilities.jl:103:15
 ```
 
-Additionally, module ExplicitImports accesses names from non-parent modules:
+Additionally, module ExplicitImports accesses names from non-owner modules:
 - `parent` has owner AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
 ````
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ using JuliaSyntax: JuliaSyntax, @K_str
 ```
 
 Additionally, module ExplicitImports accesses names from non-parent modules:
-- `parent` has parentmodule AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
+- `parent` has owner AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
 
 ````
 
@@ -77,7 +77,7 @@ using JuliaSyntax: JuliaSyntax # used at /Users/eph/ExplicitImports/src/parse_ut
 ```
 
 Additionally, module ExplicitImports accesses names from non-parent modules:
-- `parent` has parentmodule AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
+- `parent` has owner AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
 ````
 
 Note the paths of course will differ depending on the location of the code on your system.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ These can likely all be fixed by improving the code in `src/get_names_used.jl`, 
 Known issues:
 
 - `global` and `local` keywords are currently ignored
+- `baremodule` is currently not handled
+- arguments in macro definitions are not handled (may be treated incorrectly as globals)
+- arguments to `let` blocks are not handled (may be treated incorrectly as globals)
 - multi-argument `include` calls are ignored
 - In Julia, `include` adds the included code at top-level in the module in which it is called. Here, when `include` is called within a local scope, all of the code being included is treated as being within that local scope.
 - quoted code (e.g. when building Julia expressions programmatically) may be analyzed incorrectly

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ using AbstractTrees: AbstractTrees, Leaves, TreeCursor, children, nodevalue
 using JuliaSyntax: JuliaSyntax, @K_str
 ```
 
+Additionally, module ExplicitImports accesses names from non-parent modules:
+- `parent` has parentmodule AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
+
 ````
 
 Note: the `WARNING` is more or less harmless; the way this package is written, it will happen any time there is a clash, even if that clash is not realized in your code. I cannot figure out how to suppress it.
@@ -71,6 +74,9 @@ using AbstractTrees: children # used at /Users/eph/ExplicitImports/src/get_names
 using AbstractTrees: nodevalue # used at /Users/eph/ExplicitImports/src/parse_utilities.jl:96:34
 using JuliaSyntax: JuliaSyntax # used at /Users/eph/ExplicitImports/src/parse_utilities.jl:103:15
 ```
+
+Additionally, module ExplicitImports accesses names from non-parent modules:
+- `parent` has parentmodule AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:217:21
 ````
 
 Note the paths of course will differ depending on the location of the code on your system.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,8 +21,8 @@ stale_explicit_imports
 ## Detecting "improper" access of names from other modules
 
 ```@docs
-print_improper_qualified_accesses
 improper_qualified_accesses
+print_improper_qualified_accesses
 improper_qualified_accesses_nonrecursive
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,7 +33,7 @@ ExplicitImports.jl provides three functions which can be used to regression test
 ```@docs
 check_no_implicit_imports
 check_no_stale_explicit_imports
-check_all_qualified_accesses_via_parents
+check_all_qualified_accesses_via_owners
 ```
 
 ## Usage with scripts (such as `runtests.jl`)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,6 +18,14 @@ print_stale_explicit_imports
 stale_explicit_imports
 ```
 
+## Detecting "improper" access of names from other modules
+
+```@docs
+print_improper_qualified_accesses
+improper_qualified_accesses
+improper_qualified_accesses_nonrecursive
+```
+
 ## Checks to use in testing
 
 ExplicitImports.jl provides two functions which can be used to regression test that there is no reliance on implicit imports or stale explicit imports:

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,11 +28,12 @@ improper_qualified_accesses_nonrecursive
 
 ## Checks to use in testing
 
-ExplicitImports.jl provides two functions which can be used to regression test that there is no reliance on implicit imports or stale explicit imports:
+ExplicitImports.jl provides three functions which can be used to regression test that there is no reliance on implicit imports, no stale explicit imports, and no qualified accesses to names from modules other than their `Base.parentmodule`:
 
 ```@docs
 check_no_implicit_imports
 check_no_stale_explicit_imports
+check_all_qualified_accesses_via_parents
 ```
 
 ## Usage with scripts (such as `runtests.jl`)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,7 +28,7 @@ improper_qualified_accesses_nonrecursive
 
 ## Checks to use in testing
 
-ExplicitImports.jl provides three functions which can be used to regression test that there is no reliance on implicit imports, no stale explicit imports, and no qualified accesses to names from modules other than their `Base.parentmodule`:
+ExplicitImports.jl provides three functions which can be used to regression test that there is no reliance on implicit imports, no stale explicit imports, and no qualified accesses to names from modules other than their owner as determined by `Base.which`:
 
 ```@docs
 check_no_implicit_imports

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -21,4 +21,5 @@ ExplicitImports.find_implicit_imports
 ExplicitImports.get_names_used
 ExplicitImports.analyze_all_names
 ExplicitImports.inspect_session
+ExplicitImports.FileAnalysis
 ```

--- a/examples/qualified.jl
+++ b/examples/qualified.jl
@@ -1,0 +1,5 @@
+module MyMod
+using LinearAlgebra
+# sum is in `Base`, so we shouldn't access it from LinearAlgebra:
+n = LinearAlgebra.sum([1, 2, 3])
+end

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -12,7 +12,7 @@ export print_stale_explicit_imports, stale_explicit_imports,
 export print_improper_qualified_accesses, improper_qualified_accesses,
        improper_qualified_accesses_nonrecursive, check_all_qualified_accesses_via_parents
 export StaleImportsException, ImplicitImportsException, UnanalyzableModuleException,
-       FileNotFoundException, QualifiedAccessesFromNonParentException
+       FileNotFoundException, QualifiedAccessesFromNonOwnerException
 
 include("parse_utilities.jl")
 include("find_implicit_imports.jl")
@@ -193,7 +193,7 @@ function print_explicit_imports(io::IO, mod::Module, file=pathof(mod);
                         "$word, $(name_fn(mod)) accesses names from non-parent modules:")
                 for row in problematic
                     println(io,
-                            "- `$(row.name)` has parentmodule $(row.parentmodule) but it was accessed from $(row.accessing_from) at $(row.location)")
+                            "- `$(row.name)` has owner $(row.whichmodule) but it was accessed from $(row.accessing_from) at $(row.location)")
                 end
             end
         end

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -10,9 +10,9 @@ export print_explicit_imports_script
 export print_stale_explicit_imports, stale_explicit_imports,
        check_no_stale_explicit_imports, stale_explicit_imports_nonrecursive
 export print_improper_qualified_accesses, improper_qualified_accesses,
-       improper_qualified_accesses_nonrecursive
+       improper_qualified_accesses_nonrecursive, check_all_qualified_accesses_via_parents
 export StaleImportsException, ImplicitImportsException, UnanalyzableModuleException,
-       FileNotFoundException
+       FileNotFoundException, QualifiedAccessesFromNonParentException
 
 include("parse_utilities.jl")
 include("find_implicit_imports.jl")
@@ -131,7 +131,7 @@ $STRICT_PRINTING_KWARG
 * `show_locations=false`: whether or not to print locations of where the names are being used (and, if `warn_stale=true`, where the stale explicit imports are).
 * `linewidth=80`: format into lines of up to this length. Set to 0 to indicate one name should be printed per line.
 
-See also [`check_no_implicit_imports`](@ref) and [`check_no_stale_explicit_imports`](@ref).
+See also [`check_no_implicit_imports`](@ref), [`check_no_stale_explicit_imports`](@ref), and [`check_all_qualified_accesses_via_parents`](@ref).
 """
 function print_explicit_imports(io::IO, mod::Module, file=pathof(mod);
                                 skip=(mod, Base, Core), warn_stale=true,

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -15,6 +15,7 @@ export StaleImportsException, ImplicitImportsException, UnanalyzableModuleExcept
 include("parse_utilities.jl")
 include("find_implicit_imports.jl")
 include("get_names_used.jl")
+include("qualified_names.jl")
 include("checks.jl")
 
 const SKIPS_KWARG = """

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -10,7 +10,7 @@ export print_explicit_imports_script
 export print_stale_explicit_imports, stale_explicit_imports,
        check_no_stale_explicit_imports, stale_explicit_imports_nonrecursive
 export print_improper_qualified_accesses, improper_qualified_accesses,
-       improper_qualified_accesses_nonrecursive, check_all_qualified_accesses_via_parents
+       improper_qualified_accesses_nonrecursive, check_all_qualified_accesses_via_owners
 export StaleImportsException, ImplicitImportsException, UnanalyzableModuleException,
        FileNotFoundException, QualifiedAccessesFromNonOwnerException
 
@@ -131,7 +131,7 @@ $STRICT_PRINTING_KWARG
 * `show_locations=false`: whether or not to print locations of where the names are being used (and, if `warn_stale=true`, where the stale explicit imports are).
 * `linewidth=80`: format into lines of up to this length. Set to 0 to indicate one name should be printed per line.
 
-See also [`check_no_implicit_imports`](@ref), [`check_no_stale_explicit_imports`](@ref), and [`check_all_qualified_accesses_via_parents`](@ref).
+See also [`check_no_implicit_imports`](@ref), [`check_no_stale_explicit_imports`](@ref), and [`check_all_qualified_accesses_via_owners`](@ref).
 """
 function print_explicit_imports(io::IO, mod::Module, file=pathof(mod);
                                 skip=(mod, Base, Core), warn_stale=true,
@@ -190,7 +190,7 @@ function print_explicit_imports(io::IO, mod::Module, file=pathof(mod);
                        "However" : "Additionally"
                 println(io)
                 println(io,
-                        "$word, $(name_fn(mod)) accesses names from non-parent modules:")
+                        "$word, $(name_fn(mod)) accesses names from non-owner modules:")
                 for row in problematic
                     println(io,
                             "- `$(row.name)` has owner $(row.whichmodule) but it was accessed from $(row.accessing_from) at $(row.location)")

--- a/src/qualified_names.jl
+++ b/src/qualified_names.jl
@@ -1,0 +1,80 @@
+# We wish to find qualified usages of a name in which the qualifying module is not the owner of the name
+# it is also interesting to know if the name is public in the qualifying module
+
+function analyze_qualified_names(mod::Module, file=pathof(mod))
+    check_file(file)
+    per_usage_info, _ = analyze_all_names(file)
+    # Filter to qualified names
+    qualified = [row for row in per_usage_info if row.qualified_by !== nothing]
+
+    # which are in our module
+    mod_path = module_path(mod)
+    match = module_path -> all(Base.splat(isequal), zip(module_path, mod_path))
+    filter!(qualified) do nt
+        return match(nt.module_path)
+    end
+
+    # Now check:
+    table = map(qualified) do row
+        current_mod = mod
+        for submod in row.qualified_by
+            current_mod = something(trygetproperty(current_mod, submod), Some(nothing))
+            current_mod isa Module || return nothing
+        end
+        # OK, now `current_mod` is the module from which we are accessing the name!
+        # We could check here if the name is public in `current_mod`, or exported from it, etc.
+        value = trygetproperty(current_mod, row.name)
+        value === nothing && return nothing
+        value = something(value) # unwrap
+
+        # Skip things which do not have a parent module
+        parentmod = try
+            parentmodule(value)
+        catch
+            return nothing
+        end
+
+        return (; row.name,
+                value,
+                row.location,
+                accessing_from=current_mod,
+                which=which(current_mod, row.name),
+                parentmodule=parentmod,
+                accessing_from_matches_which=current_mod == which(current_mod, row.name),
+                accessing_from_matches_parent=current_mod == parentmod,)
+    end
+    return filter!(!isnothing, table)
+end
+
+function trygetproperty(x, y)
+    try
+        Some(getproperty(x, y))
+    catch
+        nothing
+    end
+end
+
+function improper_qualified_names_nonrecursive(mod::Module, file=pathof(mod))
+    return improper_qualified_names_nonrecursive(stdout, mod, file)
+end
+function improper_qualified_names_nonrecursive(io::IO, mod::Module, file=pathof(mod))
+    check_file(file)
+    qualified = analyze_qualified_names(mod, file)
+    problematic = [row for row in qualified if !row.accessing_from_matches_parent]
+    if isempty(problematic)
+        println(io, "No issues found with qualified names in $mod.")
+    else
+        # clumsy deduplication
+        d = Dict()
+        for row in problematic
+            d[(; row.name, row.accessing_from)] = row
+        end
+        println(io, "$(length(d)) issues with qualified names were found:")
+        for row in values(problematic)
+            println(io,
+                    "- $(row.name) has `parentmodule` $(row.parentmodule) but it was accessed from $(row.accessing_from) at $(row.location)")
+        end
+    end
+    ExplicitImports.parent
+    return nothing
+end

--- a/src/qualified_names.jl
+++ b/src/qualified_names.jl
@@ -72,7 +72,7 @@ function improper_qualified_names_nonrecursive(io::IO, mod::Module, file=pathof(
         println(io, "$(length(d)) issues with qualified names were found:")
         for row in values(problematic)
             println(io,
-                    "- $(row.name) has `parentmodule` $(row.parentmodule) but it was accessed from $(row.accessing_from) at $(row.location)")
+                    "- `$(row.name)` has parentmodule $(row.parentmodule) but it was accessed from $(row.accessing_from) at $(row.location)")
         end
     end
     ExplicitImports.parent

--- a/src/qualified_names.jl
+++ b/src/qualified_names.jl
@@ -147,7 +147,7 @@ In non-breaking releases of ExplicitImports:
 
 However, the result will be a Tables.jl-compatible row-oriented table (for each module), with at least all of the same columns.
 
-See also [`print_improper_qualified_accesses`](@ref) to easily compute and print these results, [`improper_qualified_accesses_nonrecursive`](@ref) for a non-recursive version which ignores submodules, and  [`check_no_XYZ`](@ref) for a version that throws errors, for regression testing.
+See also [`print_improper_qualified_accesses`](@ref) to easily compute and print these results, [`improper_qualified_accesses_nonrecursive`](@ref) for a non-recursive version which ignores submodules, and  [`check_all_qualified_accesses_via_parents`](@ref) for a version that throws errors, for regression testing.
 
 ## Example
 
@@ -165,7 +165,7 @@ end
 
 julia> include(example_path);
 
-julia> row = improper_qualified_accesses(MyMod, example_path)[MyMod][1];
+julia> row = improper_qualified_accesses(MyMod, example_path)[1][2][1];
 
 julia> (; row.name, row.accessing_from, row.parentmodule)
 (name = :sum, accessing_from = LinearAlgebra, parentmodule = Base)
@@ -181,6 +181,17 @@ function improper_qualified_accesses(mod::Module, file=pathof(mod); skip=(Base =
                                                                   skip)
             for (submodule, path) in submodules]
 end
+
+"""
+    print_improper_qualified_accesses([io::IO=stdout,] mod::Module, file=pathof(mod))
+
+Runs [`improper_qualified_accesses`](@ref) and prints the results.
+
+Note that the particular printing may change in future non-breaking releases of ExplicitImports.
+
+See also [`print_explicit_imports`](@ref) and [`check_all_qualified_accesses_via_parents`](@ref).
+"""
+print_improper_qualified_accesses
 
 function print_improper_qualified_accesses(mod::Module, file=pathof(mod))
     return print_improper_qualified_accesses(stdout, mod, file)

--- a/src/qualified_names.jl
+++ b/src/qualified_names.jl
@@ -1,9 +1,16 @@
 # We wish to find qualified usages of a name in which the qualifying module is not the owner of the name
 # it is also interesting to know if the name is public in the qualifying module
 
-function analyze_qualified_names(mod::Module, file=pathof(mod))
+function analyze_qualified_names(mod::Module, file=pathof(mod);
+                                 # private undocumented kwarg for hoisting this analysis
+                                 file_analysis=get_names_used(file))
     check_file(file)
-    per_usage_info, _ = analyze_all_names(file)
+    (; per_usage_info, tainted) = filter_to_module(file_analysis, mod)
+    # Do we want to do anything with `tainted`? This means there is unanalyzable code here
+    # Probably that means we could miss qualified names to report, but not that
+    # something there would invalidate the qualified names with issues we did find.
+    # For now let's ignore it.
+
     # Filter to qualified names
     qualified = [row for row in per_usage_info if row.qualified_by !== nothing]
 
@@ -14,67 +21,100 @@ function analyze_qualified_names(mod::Module, file=pathof(mod))
         return match(nt.module_path)
     end
 
+    table = @NamedTuple{name::Symbol,location::String,value::Any,accessing_from::Module,
+                        parentmodule::Module,
+                        accessing_from_matches_parent::Bool}[]
     # Now check:
-    table = map(qualified) do row
-        current_mod = mod
-        for submod in row.qualified_by
-            current_mod = something(trygetproperty(current_mod, submod), Some(nothing))
-            current_mod isa Module || return nothing
-        end
-        # OK, now `current_mod` is the module from which we are accessing the name!
-        # We could check here if the name is public in `current_mod`, or exported from it, etc.
-        value = trygetproperty(current_mod, row.name)
-        value === nothing && return nothing
-        value = something(value) # unwrap
-
-        # Skip things which do not have a parent module
-        parentmod = try
-            parentmodule(value)
-        catch
-            return nothing
-        end
-
-        return (; row.name,
-                value,
-                row.location,
-                accessing_from=current_mod,
-                which=which(current_mod, row.name),
-                parentmodule=parentmod,
-                accessing_from_matches_which=current_mod == which(current_mod, row.name),
-                accessing_from_matches_parent=current_mod == parentmod,)
+    for row in qualified
+        output = process_qualified_row(row, mod)
+        output === nothing && continue
+        push!(table, output)
     end
-    return filter!(!isnothing, table)
+    unique!(nt -> (; nt.name, nt.accessing_from), table)
+    sort!(table; by=nt -> (; nt.name, nt.location))
+    return table
 end
 
-function trygetproperty(x, y)
-    try
-        Some(getproperty(x, y))
+function process_qualified_row(row, mod)
+    current_mod = mod
+    for submod in row.qualified_by
+        current_mod = something(trygetproperty(current_mod, submod), Some(nothing))
+        current_mod isa Module || return nothing
+    end
+    # OK, now `current_mod` is the module from which we are accessing the name!
+    # We could check here if the name is public in `current_mod`, or exported from it, etc.
+    value = trygetproperty(current_mod, row.name)
+    value === nothing && return nothing
+    value = something(value) # unwrap
+
+    # Skip things which do not have a parent module
+    applicable(parentmodule, value) || return nothing
+    # We still need a try-catch since `applicable` doesn't seem to catch everything, e.g.
+    # `MethodError: no method matching parentmodule(::Type{Union{Adjoint{T, S}, Transpose{T, S}}})`
+    parentmod = try
+        parentmodule(value)
     catch
-        nothing
+        return nothing
     end
+
+    return (; row.name,
+            row.location,
+            value,
+            accessing_from=current_mod,
+            parentmodule=parentmod,
+            accessing_from_matches_parent=current_mod == parentmod,)
 end
 
-function improper_qualified_names_nonrecursive(mod::Module, file=pathof(mod))
-    return improper_qualified_names_nonrecursive(stdout, mod, file)
+# We can't just trust `hasproperty` since e.g. `hasproperty(Base, :Core) == false`:
+# (https://github.com/JuliaLang/julia/issues/47150)
+function trygetproperty(x::Module, y)
+    return isdefined(x, y) ? Some(getproperty(x, y)) : nothing
 end
-function improper_qualified_names_nonrecursive(io::IO, mod::Module, file=pathof(mod))
+
+function improper_qualified_names_nonrecursive(mod::Module, file=pathof(mod);
+                                               # private undocumented kwarg for hoisting this analysis
+                                               file_analysis=get_names_used(file))
     check_file(file)
-    qualified = analyze_qualified_names(mod, file)
-    problematic = [row for row in qualified if !row.accessing_from_matches_parent]
-    if isempty(problematic)
-        println(io, "No issues found with qualified names in $mod.")
-    else
-        # clumsy deduplication
-        d = Dict()
-        for row in problematic
-            d[(; row.name, row.accessing_from)] = row
-        end
-        println(io, "$(length(d)) issues with qualified names were found:")
-        for row in values(problematic)
+    qualified = analyze_qualified_names(mod, file; file_analysis)
+    # We allow `Base.x` for names that are owned by Core, like `NamedTuple`
+    problematic = [row
+                   for row in qualified
+                   if !row.accessing_from_matches_parent &&
+                      !(row.parentmodule == Core && row.accessing_from == Base)]
+    return problematic
+end
+
+function improper_qualified_names(mod::Module, file=pathof(mod))
+    check_file(file)
+    submodules = find_submodules(mod, file)
+    file_analysis = Dict{String,FileAnalysis}()
+    fill_cache!(file_analysis, last.(submodules))
+    return [submodule => improper_qualified_names_nonrecursive(submodule, path;
+                                                               file_analysis=file_analysis[path])
+            for (submodule, path) in submodules]
+end
+
+function print_improper_qualified_names(mod::Module, file=pathof(mod))
+    return print_improper_qualified_names(stdout, mod, file)
+end
+
+function print_improper_qualified_names(io::IO, mod::Module, file=pathof(mod))
+    check_file(file)
+    for (i, (mod, problematic)) in enumerate(improper_qualified_names(mod, file))
+        i == 1 || println(io)
+        if isempty(problematic)
+            println(io, "Module $mod accesses names only from parent modules.")
+        else
             println(io,
-                    "- `$(row.name)` has parentmodule $(row.parentmodule) but it was accessed from $(row.accessing_from) at $(row.location)")
+                    "Module $mod accesses names from non-parent modules:")
+            for row in problematic
+                println(io,
+                        "- `$(row.name)` has parentmodule $(row.parentmodule) but it was accessed from $(row.accessing_from) at $(row.location)")
+            end
         end
     end
+
+    # We leave this so we can have non-trivial printout when running this function on ExplicitImports:
     ExplicitImports.parent
     return nothing
 end

--- a/test/TestModC.jl
+++ b/test/TestModC.jl
@@ -14,6 +14,8 @@ func_c() = (local9 = 1; f())
 # fully qualified usage of implicitly available exported name
 y = Exporter.exported_a()
 
+TestModA.SubModB.h
+
 # explicitly imported name, which is also available implicitly
 z = exported_b()
 

--- a/test/public_compat.jl
+++ b/test/public_compat.jl
@@ -1,0 +1,11 @@
+# based on:
+# https://github.com/JuliaLang/Public.jl/blob/a0e40de2b67a255dee7ffdf392e7b794eb49d44f/src/Public.jl#L9-L19
+@static if Base.VERSION >= v"1.11.0-DEV.469"
+    macro public_or_export(symbol::Symbol)
+        return esc(Expr(:public, symbol))
+    end
+else
+    macro public_or_export(symbol::Symbol)
+        return esc(Expr(:export, symbol))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -356,6 +356,15 @@ end
           [(; name=:exported_c), (; name=:exported_d)]
     @test isempty(lookup[TestModA])
 
+    per_usage_info, _ = analyze_all_names("TestModC.jl")
+    testmodc = DataFrame(analyze_per_usage_info(per_usage_info))
+    qualified_row = only(subset(testmodc, :name => ByRow(==(:exported_a))))
+    @test qualified_row.analysis_code == ExplicitImports.IgnoredQualified
+    @test qualified_row.qualified_by == [:Exporter]
+
+    qualified_row2 = only(subset(testmodc, :name => ByRow(==(:h))))
+    @test qualified_row2.qualified_by == [:TestModA, :SubModB]
+
     # Printing
     str = sprint(print_stale_explicit_imports, TestModA, "TestModA.jl")
     @test contains(str, "TestModA has no stale explicit imports")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,12 +101,12 @@ end
     @test !isempty(ret[TestQualifiedAccess])
     row = only(ret[TestQualifiedAccess])
     @test row.name == :ABC
-    @test row.parentmodule == TestQualifiedAccess.Bar
+    @test row.whichmodule == TestQualifiedAccess.Bar
     @test row.accessing_from == TestQualifiedAccess.FooModule
-    @test row.accessing_from_matches_parent == false
+    @test row.accessing_from_matches_which == false
 
     # check_all_qualified_accesses_via_parents
-    ex = QualifiedAccessesFromNonParentException
+    ex = QualifiedAccessesFromNonOwnerException
     @test_throws ex check_all_qualified_accesses_via_parents(TestQualifiedAccess,
                                                              "test_qualified_access.jl")
 
@@ -119,12 +119,12 @@ end
     str = sprint(print_improper_qualified_accesses, TestQualifiedAccess,
                  "test_qualified_access.jl")
     @test contains(str, "accesses names from non-parent modules")
-    @test contains(str, "`ABC` has parentmodule")
+    @test contains(str, "`ABC` has owner")
 
     # Printing via `print_explicit_imports`
     str = sprint(print_explicit_imports, TestQualifiedAccess, "test_qualified_access.jl")
     @test contains(str, "accesses names from non-parent modules")
-    @test contains(str, "`ABC` has parentmodule")
+    @test contains(str, "`ABC` has owner")
 end
 
 @testset "structs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Logging
 using AbstractTrees
 using ExplicitImports: is_function_definition_arg, SyntaxNodeWrapper, get_val
 using ExplicitImports: is_struct_type_param, is_struct_field_name, is_for_arg,
-                       is_generator_arg, analyze_per_usage_info
+                       is_generator_arg
 using TestPkg, Markdown
 
 # DataFrames version of `filter_to_module`
@@ -129,7 +129,7 @@ end
           ["using LinearAlgebra: LinearAlgebra"]
 
     per_usage_info, _ = analyze_all_names("test_mods.jl")
-    df = DataFrame(analyze_per_usage_info(per_usage_info))
+    df = DataFrame(per_usage_info)
     subset!(df, :module_path => ByRow(==([:TestMod9])), :name => ByRow(==(:i1)))
     @test all(==(ExplicitImports.InternalGenerator), df.analysis_code)
 end
@@ -139,7 +139,7 @@ end
           ["using LinearAlgebra: LinearAlgebra", "using LinearAlgebra: I"]
 
     per_usage_info, _ = analyze_all_names("test_mods.jl")
-    df = DataFrame(analyze_per_usage_info(per_usage_info))
+    df = DataFrame(per_usage_info)
     subset!(df, :module_path => ByRow(==([:TestMod10])), :name => ByRow(==(:I)))
     # First one is internal, second one external
     @test df.analysis_code == [ExplicitImports.InternalAssignment, ExplicitImports.External]
@@ -152,7 +152,7 @@ end
            "using LinearAlgebra: svd"]
 
     per_usage_info, _ = analyze_all_names("test_mods.jl")
-    df = DataFrame(analyze_per_usage_info(per_usage_info))
+    df = DataFrame(per_usage_info)
     subset!(df, :module_path => ByRow(==([:TestMod11])))
 
     I_codes = subset(df, :name => ByRow(==(:I))).analysis_code
@@ -173,7 +173,7 @@ end
            "using LinearAlgebra: svd"]
 
     per_usage_info, _ = analyze_all_names("test_mods.jl")
-    df = DataFrame(analyze_per_usage_info(per_usage_info))
+    df = DataFrame(per_usage_info)
     subset!(df, :module_path => ByRow(==([:TestMod12])))
 
     I_codes = subset(df, :name => ByRow(==(:I))).analysis_code
@@ -357,7 +357,7 @@ end
     @test isempty(lookup[TestModA])
 
     per_usage_info, _ = analyze_all_names("TestModC.jl")
-    testmodc = DataFrame(analyze_per_usage_info(per_usage_info))
+    testmodc = DataFrame(per_usage_info)
     qualified_row = only(subset(testmodc, :name => ByRow(==(:exported_a))))
     @test qualified_row.analysis_code == ExplicitImports.IgnoredQualified
     @test qualified_row.qualified_by == [:Exporter]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,6 +129,7 @@ end
                                                             "test_qualified_access.jl";
                                                             ignore,
                                                             require_submodule_access=true)
+                                                
     ignore = (TestQualifiedAccess.FooModule => TestQualifiedAccess.Bar,
               TestQualifiedAccess.FooModule => TestQualifiedAccess.FooModule.FooSub)
     @test check_all_qualified_accesses_via_owners(TestQualifiedAccess,

--- a/test/test_qualified_access.jl
+++ b/test/test_qualified_access.jl
@@ -1,0 +1,38 @@
+module TestQualifiedAccess
+# https://github.com/ericphanson/ExplicitImports.jl/issues/48
+module Bar
+struct ABC
+end
+
+struct DEF end
+
+struct HIJ end
+
+export ABC
+end
+
+module FooModule
+using ..Main: @public_or_export
+using ..Bar: ABC, DEF, HIJ
+export DEF
+
+@public_or_export HIJ
+
+ABC()
+HIJ()
+end
+
+# Qualified access to `ABC` from the wrong module
+FooModule.ABC
+
+# Qualified access to `DEF` from non-parent module, BUT `DEF` is exported in `FooModule`,
+# so it's OK
+FooModule.DEF
+
+# This one is either exported again or marked public, depending on Julia version
+FooModule.HIJ
+
+# Accessing it again does not affect results (we only report one)
+FooModule.DEF
+
+end # TestQualifiedAccess

--- a/test/test_qualified_access.jl
+++ b/test/test_qualified_access.jl
@@ -1,15 +1,14 @@
 module TestQualifiedAccess
 # https://github.com/ericphanson/ExplicitImports.jl/issues/48
 module Bar
-struct ABC
-end
+struct ABC end
 
 struct DEF end
 
 struct HIJ end
 
 export ABC
-end
+end # Bar
 
 module FooModule
 using ..Main: @public_or_export
@@ -18,14 +17,22 @@ export DEF
 
 @public_or_export HIJ
 
+module FooSub
+struct X end
+end # FooSub
+
+using .FooSub: X
+X()
+
 ABC()
 HIJ()
+X()
 end
 
 # Qualified access to `ABC` from the wrong module
 FooModule.ABC
 
-# Qualified access to `DEF` from non-parent module, BUT `DEF` is exported in `FooModule`,
+# Qualified access to `DEF` from non-owner module, BUT `DEF` is exported in `FooModule`,
 # so it's OK
 FooModule.DEF
 
@@ -34,5 +41,8 @@ FooModule.HIJ
 
 # Accessing it again does not affect results (we only report one)
 FooModule.DEF
+
+# This is allowed unless `require_submodule_access=true`
+FooModule.X
 
 end # TestQualifiedAccess


### PR DESCRIPTION
closes #48 

I think I've got the rough functionality working:
```julia
julia> ExplicitImports.improper_qualified_names_nonrecursive(ExplicitImports)
1 issues with qualified names were found:
- `parent` has parentmodule AbstractTrees but it was accessed from ExplicitImports at /Users/eph/ExplicitImports/src/qualified_names.jl:78:21
```

It isn't clear to me whether or not what matters is `parentmodule`, `which`, or maybe in 1.11, `ispublic`... I might mark this experimental and choose to change the criteria later.

before merging, needs:
- [x] tests
- [x] docstring

and possibly in a followup:
- [x] recursive variant
- [x] `check_` variant

