### PR TITLE
don't skip source modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.4.4"
+version = "1.4.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -16,9 +16,10 @@ JuliaSyntax = "0.4.8"
 LinearAlgebra = "<0.0.1, 1"
 Logging = "<0.0.1, 1"
 Markdown = "<0.0.1, 1"
+Pkg = "<0.0.1, 1"
+UUIDs = "<0.0.1, 1"
 TOML = "<0.0.1, 1"
 Test = "<0.0.1, 1"
-Pkg = "<0.0.1, 1"
 julia = "1.7"
 
 [extras]
@@ -28,7 +29,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "DataFrames", "LinearAlgebra", "Logging", "Markdown", "Pkg", "Test"]
+test = ["Aqua", "DataFrames", "LinearAlgebra", "Logging", "Markdown", "Pkg", "UUIDs", "Test"]

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -246,7 +246,6 @@ function explicit_imports_nonrecursive(mod::Module, file=pathof(mod);
     needed_names = Set(nt.name for nt in needs_explicit_import)
     filter!(all_implicit_imports) do (k, v)
         k in needed_names || return false
-        should_skip(v.source; skip) && return false
         any(mod -> should_skip(mod; skip), v.exporters) && return false
         return true
     end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -50,3 +50,10 @@ using ..Exporter2
 
 exported_a
 end
+
+# https://github.com/ericphanson/ExplicitImports.jl/issues/29
+module Mod29
+using UUIDs
+
+v = UUID[]
+end


### PR DESCRIPTION
closes https://github.com/ericphanson/ExplicitImports.jl/issues/29

I realized after looking into this one that we almost handle it correctly already, there is just an incorrect `skip`