### PR TITLE
By default, ignore "improper" imports/accesses from within the same package

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -28,11 +28,12 @@ function print_stale_explicit_imports(mod::Module, file=pathof(mod); kw...)
 end
 
 function print_stale_explicit_imports(io::IO, mod::Module, file=pathof(mod); strict=true,
-                                      show_locations=false)
+                                      show_locations=false, allow_internal_imports=true)
     @warn "[print_stale_explicit_imports] deprecated in favor of `print_explicit_imports`" maxlog = 1
 
     check_file(file)
-    for (i, (mod, stale_imports)) in enumerate(improper_explicit_imports(mod, file; strict))
+    for (i, (mod, stale_imports)) in
+        enumerate(improper_explicit_imports(mod, file; strict, allow_internal_imports))
         if !isnothing(stale_imports)
             filter!(row -> row.stale, stale_imports)
         end
@@ -57,17 +58,20 @@ function print_stale_explicit_imports(io::IO, mod::Module, file=pathof(mod); str
     end
 end
 
-function print_improper_qualified_accesses(mod::Module, file=pathof(mod))
-    return print_improper_qualified_accesses(stdout, mod, file)
+function print_improper_qualified_accesses(mod::Module, file=pathof(mod);
+                                           allow_internal_accesses=true)
+    return print_improper_qualified_accesses(stdout, mod, file; allow_internal_accesses)
 end
 
 function print_improper_qualified_accesses(io::IO, mod::Module, file=pathof(mod);
-                                           report_non_public=VERSION >= v"1.11-")
+                                           report_non_public=VERSION >= v"1.11-",
+                                           allow_internal_accesses=true)
     @warn "[print_improper_qualified_accesses] deprecated in favor of `print_explicit_imports`" maxlog = 1
     print_explicit_imports(io, mod, file;
                            warn_improper_qualified_accesses=true,
                            warn_improper_explicit_imports=false,
                            warn_implicit_imports=false,
+                           allow_internal_accesses,
                            report_non_public)
     # We leave this so we can have non-trivial printout when running this function on ExplicitImports:
     ExplicitImports.parent

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -64,7 +64,7 @@ end
                                                                                            TestQualifiedAccess,
                                                                                            "test_qualified_access.jl";
                                                                                            allow_internal_accesses=false))
-    @test contains(str, "accesses 1 name from non-owner modules")
+    @test contains(str, "accesses 2 names from non-owner modules")
     @test contains(str, "`ABC` has owner")
 
     @test_logs (:warn, r"deprecated") @test only_name_source(stale_explicit_imports_nonrecursive(TestModA.SubModB.TestModA.TestModC,

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -52,16 +52,18 @@ end
     @test contains(str, "DynMod could not be accurately analyzed")
 
     # Printing via `print_stale_explicit_imports`
-    str = @test_logs (:warn, r"deprecated") sprint(print_stale_explicit_imports,
-                                                   TestModA,
-                                                   "TestModA.jl")
+    str = @test_logs (:warn, r"deprecated") sprint(io -> print_stale_explicit_imports(io,
+                                                                                      TestModA,
+                                                                                      "TestModA.jl";
+                                                                                      allow_internal_imports=false))
     @test contains(str, "TestModA has no stale explicit imports")
     @test contains(str, "TestModC has stale explicit imports for these unused names")
 
     # Printing via `print_improper_qualified_accesses`
-    str = @test_logs (:warn, r"deprecated") sprint(print_improper_qualified_accesses,
-                                                   TestQualifiedAccess,
-                                                   "test_qualified_access.jl")
+    str = @test_logs (:warn, r"deprecated") sprint(io -> print_improper_qualified_accesses(io,
+                                                                                           TestQualifiedAccess,
+                                                                                           "test_qualified_access.jl";
+                                                                                           allow_internal_accesses=false))
     @test contains(str, "accesses 1 name from non-owner modules")
     @test contains(str, "`ABC` has owner")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -345,8 +345,14 @@ end
     @test check_all_explicit_imports_via_owners(TestModA, "TestModA.jl";
                                                 allow_internal_imports=false) === nothing
     @test_throws ExplicitImportsFromNonOwnerException check_all_explicit_imports_via_owners(ModImports,
-                                                                                            "imports.jl")
+                                                                                            "imports.jl";
+                                                                                            allow_internal_imports=false)
 
+    # allow_internal_imports=true
+    @test_throws ExplicitImportsFromNonOwnerException check_all_explicit_imports_via_owners(ModImports,
+                                                                                            "imports.jl";)
+    @test check_all_explicit_imports_via_owners(ModImports,
+                                                "imports.jl"; ignore=(:map,)) === nothing
     # Test the printing is hitting our formatted errors
     str = exception_string() do
         return check_all_explicit_imports_via_owners(ModImports,
@@ -395,6 +401,13 @@ end
                                                 ignore=(:ABC, :X),
                                                 require_submodule_import=true,
                                                 allow_internal_imports=false) === nothing
+
+    # allow_internal_imports = true
+    @test_throws NonPublicExplicitImportsException check_all_explicit_imports_are_public(ModImports,
+                                                                                         "imports.jl";)
+    @test check_all_explicit_imports_are_public(ModImports,
+                                                "imports.jl"; ignore=(:map, :_svd!)) ===
+          nothing
 end
 
 @testset "structs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -317,6 +317,11 @@ end
                                                   "test_qualified_access.jl";
                                                   skip, ignore=(:X, :map),
                                                   allow_internal_accesses=false) === nothing
+
+    # allow_internal_accesses=true
+    @test check_all_qualified_accesses_are_public(TestQualifiedAccess,
+                                                  "test_qualified_access.jl";
+                                                  ignore=(:map,)) === nothing
 end
 
 @testset "improper explicit imports" begin

--- a/test/test_qualified_access.jl
+++ b/test/test_qualified_access.jl
@@ -45,4 +45,8 @@ FooModule.DEF
 # This is allowed unless `require_submodule_access=true` or we are detecting any non-public access
 FooModule.X
 
+using LinearAlgebra: LinearAlgebra
+
+LinearAlgebra.map
+
 end # TestQualifiedAccess


### PR DESCRIPTION
I expect this would be more annoying than not in most cases