### PR TITLE
Fix ref to `explicit_imports` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ExplicitImports.jl helps detect implicit imports and mitigate issues with the al
 
 | Problem               | Example                             | Interactive detection                                  | Programmatic detection        | Regression-testing check                  |
 | --------------------- | ----------------------------------- | ------------------------------------------------------ | ----------------------------- | ----------------------------------------- |
-| Implicit imports      | `using LinearAlgebra`               | `print_explicit_imports`                               | `implicit_imports`            | `check_no_implicit_imports`               |
+| Implicit imports      | `using LinearAlgebra`               | `print_explicit_imports`                               | `explicit_imports`            | `check_no_implicit_imports`               |
 | Non-owning import     | `using LinearAlgebra: map`          | `print_explicit_imports`                               | `improper_explicit_imports`   | `check_all_explicit_imports_via_owners`   |
 | Non-public import     | `using LinearAlgebra: _svd!`        | `print_explicit_imports` with `report_non_public=true` | `improper_explicit_imports`   | `check_all_explicit_imports_are_public`   |
 | Stale import          | `using LinearAlgebra: svd # unused` | `print_explicit_imports`                               | `improper_explicit_imports`   | `check_no_stale_explicit_imports`         |


### PR DESCRIPTION
The readme contains a reference to an `implicit_imports` method that does not exist. It seems like it should reference `explicit_imports` instead, which is what this PR changes.