### PR TITLE
fix package loading in app use-case

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,9 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 AbstractTrees = "0.4.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-version = "1.11.0"
+version = "1.11.1"
 authors = ["Eric P. Hanson"]
 
 [deps]
@@ -10,6 +10,7 @@ JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 AbstractTrees = "0.4.5"
@@ -35,10 +36,9 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Aqua", "DataFrames", "LinearAlgebra", "Logging", "Pkg", "UUIDs", "Reexport", "Test"]
+test = ["Aqua", "DataFrames", "LinearAlgebra", "Logging", "UUIDs", "Reexport", "Test"]

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Alternatively, one can use the `main` function directly:
 julia -e 'using ExplicitImports: main; main(["--print", "--checklist", "exclude_all_qualified_accesses_are_public"])'
 ```
 
-On Julia v1.12+, one can use the syntax `julia -m ExplicitImports path` to run ExplicitImports on a particular path (defaulting to the current working directory). See [here](https://docs.julialang.org/en/v1.12-dev/NEWS/#Command-line-option-changes) for the `-m` flag. ExplicitImports.jl must be installed in the project you start Julia with (e.g. in your v1.12 default environment), and the target package to analyze must be installable on the same version of Julia (e.g. no out-of-date Manifest.toml present in the package environment).
+On Julia v1.12+, one can use the syntax `julia -m ExplicitImports path` to run ExplicitImports on a particular path (defaulting to the current working directory). See [here](https://docs.julialang.org/en/v1.12-dev/NEWS/#Command-line-option-changes) for the `-m` flag. ExplicitImports.jl must be installed in the project you start Julia with (e.g. in your v1.12 default environment), and the target package to analyze must be installable on the same version of Julia.
 
 For example, using [`juliaup`](https://github.com/JuliaLang/juliaup)'s `nightly` feature, one can run ExplicitImports on v1.12 as follows.
 

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -10,6 +10,7 @@ using TOML: parsefile
 using Compat: Compat, @compat
 using Markdown: Markdown
 using PrecompileTools: @setup_workload, @compile_workload
+using Pkg: Pkg
 
 export print_explicit_imports, explicit_imports, check_no_implicit_imports,
        explicit_imports_nonrecursive

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -6,7 +6,7 @@ using JuliaSyntax, AbstractTrees
 # the former occurs for all users, the latter only for developers of this package
 using JuliaSyntax: parse
 using AbstractTrees: parent
-using TOML: parsefile
+using TOML: TOML, parsefile
 using Compat: Compat, @compat
 using Markdown: Markdown
 using PrecompileTools: @setup_workload, @compile_workload

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -397,6 +397,7 @@ end
 @setup_workload begin
     @compile_workload begin
         sprint(print_explicit_imports, ExplicitImports, @__FILE__)
+        precompile(main, (Vector{String},))
     end
 end
 

--- a/src/get_names_used.jl
+++ b/src/get_names_used.jl
@@ -523,7 +523,7 @@ function analyze_per_usage_info(per_usage_info)
     # For each scope, we want to understand if there are any global usages of the name in that scope
     # First, throw away all qualified usages, they are irrelevant
     # Next, if a name is on the RHS of an import, we don't care, so throw away
-    # Next, if the name is beign used at global scope, obviously it is a global
+    # Next, if the name is begin used at global scope, obviously it is a global
     # Otherwise, we are in local scope:
     #   1. Next, if the name is a function arg, then this is not a global name (essentially first usage is assignment)
     #   2. Otherwise, if first usage is assignment, then it is local, otherwise it is global

--- a/src/get_names_used.jl
+++ b/src/get_names_used.jl
@@ -213,11 +213,11 @@ function get_import_lhs(import_rhs_leaf)
     if parents_match(import_rhs_leaf, (K"importpath", K":"))
         n = first(children(get_parent(import_rhs_leaf, 2)))
         @assert kind(n) == K"importpath"
-        return get_val.(children(n))
+        return filter!(!isnothing, get_val.(children(n)))
     elseif parents_match(import_rhs_leaf, (K"importpath", K"as", K":"))
         n = first(children(get_parent(import_rhs_leaf, 3)))
         @assert kind(n) == K"importpath"
-        return get_val.(children(n))
+        return filter!(!isnothing, get_val.(children(n)))
     else
         error("does not seem to be an import RHS")
     end

--- a/src/main.jl
+++ b/src/main.jl
@@ -40,11 +40,20 @@ function get_manifest_julia_version(manifest_path)
     return tryparse(VersionNumber, v_str)
 end
 
+function julia_has_color()
+    if isdefined(Base, :ioproperties)
+        return get(Base.ioproperties(stderr), :color, false)
+    else
+        # safe fallback
+        return false
+    end
+end
+
 function activate_and_load(package, project_path)
     @info "Loading package at $(abspath(project_path))"
     manifest_path = Pkg.Types.manifestfile_path(dirname(project_path))
     v = get_manifest_julia_version(manifest_path)
-    pkg_io = IOContext(Base.BufferStream(), :color => get(Base.ioproperties(stderr), :color, false))
+    pkg_io = IOContext(Base.BufferStream(), :color => julia_has_color())
     try # we will dump `pkg_io` to stderr if there is an error
         if !isnothing(v) && v.major == VERSION.major && v.minor == VERSION.minor
             # unless we already have a manifest that should work, we will use a temp env

--- a/src/main.jl
+++ b/src/main.jl
@@ -46,12 +46,13 @@ function activate_and_load(package, project_path)
     v = get_manifest_julia_version(manifest_path)
     pkg_io = IOContext(Base.BufferStream(), :color => get(Base.ioproperties(stderr), :color, false))
     try # we will dump `pkg_io` to stderr if there is an error
-        if !isnothing(v) && (v.major == VERSION.major || v.minor == VERSION.minor)
+        if !isnothing(v) && v.major == VERSION.major && v.minor == VERSION.minor
             # unless we already have a manifest that should work, we will use a temp env
             # we don't want to:
             # 1. error because the user has a manifest with a different julia version
             # 2. create a new manifest with `Pkg.instantiate` when one does not exist
             @info "Using existing manifest at $manifest_path"
+            @debug "Manifest version: $v. Current version: $VERSION"
             @static if isdefined(Base, :set_active_project)
                 Base.set_active_project(project_path)
             else

--- a/src/main.jl
+++ b/src/main.jl
@@ -31,24 +31,59 @@ function get_package_name_from_project_toml(path)
     return package, project_path
 end
 
+function get_manifest_julia_version(manifest_path)
+    isfile(manifest_path) || return nothing
+    manifest = TOML.tryparsefile(manifest_path)
+    isnothing(manifest) && return nothing
+    v_str = get(manifest, "julia_version", nothing)
+    isnothing(v_str) && return nothing
+    return tryparse(VersionNumber, v_str)
+end
+
 function activate_and_load(package, project_path)
     @info "Loading package at $(abspath(project_path))"
-    pushfirst!(LOAD_PATH, project_path)
-    try
-        @static if isdefined(Base, :set_active_project)
-            Base.set_active_project(project_path)
-        else
-            @eval Main begin
-                $Pkg.activate($project_path)
+    manifest_path = Pkg.Types.manifestfile_path(dirname(project_path))
+    v = get_manifest_julia_version(manifest_path)
+    pkg_io = IOContext(Base.BufferStream(), :color => get(Base.ioproperties(stderr), :color, false))
+    try # we will dump `pkg_io` to stderr if there is an error
+        if !isnothing(v) && (v.major == VERSION.major || v.minor == VERSION.minor)
+            # unless we already have a manifest that should work, we will use a temp env
+            # we don't want to:
+            # 1. error because the user has a manifest with a different julia version
+            # 2. create a new manifest with `Pkg.instantiate` when one does not exist
+            @info "Using existing manifest at $manifest_path"
+            @static if isdefined(Base, :set_active_project)
+                Base.set_active_project(project_path)
+            else
+                Pkg.activate(project_path; io=pkg_io)
+                Pkg.instantiate(; io=pkg_io)
             end
+        else
+            # safe fallback: temp env
+            @info "Creating new manifest in temporary environment"
+            Pkg.activate(; temp=true, io=pkg_io)
+            Pkg.develop(; path=dirname(project_path), io=pkg_io)
         end
-        Pkg.instantiate();
+    catch
+        # Dump pkg io
+        close(pkg_io)
+        write(stderr, read(pkg_io))
+        rethrow()
+    end
+
+    # In an apps context, our `LOAD_PATH` may not include the active project!
+    # We have just set an active project we do want to load from, so let's push
+    # it into our `LOAD_PATH`
+    load_path_project = Base.active_project()
+    pushfirst!(LOAD_PATH, load_path_project)
+    try
         @eval Main begin
             using $package: $package
-            using ExplicitImports: ExplicitImports
         end
     finally
-        if !isempty(LOAD_PATH) && first(LOAD_PATH) == project_path
+        # let us try to be good citizens and undo the `LOAD_PATH` modification
+        # we have made, if no one has messed with since.
+        if !isempty(LOAD_PATH) && first(LOAD_PATH) == load_path_project
             popfirst!(LOAD_PATH)
         end
     end
@@ -58,7 +93,7 @@ function run_checks(package, selected_checks)
     for check in selected_checks
         @info "Checking $check"
         try
-            @eval Main ExplicitImports.$(Symbol("check_" * check))($package)
+            @eval Main $ExplicitImports.$(Symbol("check_" * check))($package)
         catch e
             printstyled(stderr, "ERROR: "; bold=true, color=:red)
             Base.showerror(stderr, e)
@@ -185,7 +220,7 @@ function main(args)
     activate_and_load(package, project_path)
     if should_print
         try
-            @eval Main ExplicitImports.print_explicit_imports($package)
+            @eval Main $ExplicitImports.print_explicit_imports($package)
         catch e
             printstyled(stderr, "ERROR: "; bold=true, color=:red)
             Base.showerror(stderr, e)


### PR DESCRIPTION
because apps run with a very restricted `LOAD_PATH`, the previous way of loading the package in `main` wasn't working. This seems to fix it.

It is not easy to test because we need to install the app to test that part (we already test the `-m` functionality with another process), but I hope eventually we can. For now it is experimental functionality so I think it's alright.