### PR TITLE
try to improve inferability and ttfx

### DIFF
--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -347,9 +347,10 @@ function _find_submodules(mod)
 end
 
 function get_project_file(mod)
-    pkgdir(mod) === nothing && return nothing
+    dir = pkgdir(mod)
+    dir === nothing && return nothing
     for filename in ("Project.toml", "JuliaProject.toml")
-        pfile = joinpath(pkgdir(mod), filename)
+        pfile = joinpath(dir, filename)
         isfile(pfile) && return pfile
     end
     return nothing
@@ -394,11 +395,13 @@ function inspect_session(io::IO; skip=(Base, Core), inner=print_explicit_imports
     end
 end
 
+include("precompile.jl")
+
 @setup_workload begin
     @compile_workload begin
-        sprint(print_explicit_imports, ExplicitImports, @__FILE__)
-        precompile(main, (Vector{String},))
+        sprint(print_explicit_imports, ExplicitImports, @__FILE__; context=:color => true)
     end
 end
+
 
 end

--- a/src/find_implicit_imports.jl
+++ b/src/find_implicit_imports.jl
@@ -44,7 +44,7 @@ function find_implicit_imports(mod::Module; skip=(mod, Base, Core))
             # This happens when you get stuff like
             # `WARNING: both Exporter3 and Exporter2 export "exported_a"; uses of it in module TestModA must be qualified`
             # and there is an ambiguity, and the name is in fact not resolved in `mod`
-            clash = err == ErrorException("\"$name\" is not defined in module $mod")
+            clash = (err == ErrorException("\"$name\" is not defined in module $mod"))::Bool
             # if it is something else, rethrow
             clash || rethrow()
             missing

--- a/src/get_names_used.jl
+++ b/src/get_names_used.jl
@@ -461,7 +461,7 @@ function analyze_all_names(file)
         # if we don't find any identifiers (or macro names) in a module, I think it's OK to mark it as
         # "not-seen"? Otherwise we need to analyze every leaf, not just the identifiers
         # and that sounds slow. Seems like a very rare edge case to have no identifiers...
-        kind(leaf) in (K"Identifier", K"MacroName", K"StringMacroName") || continue
+        (kind(leaf) in (K"Identifier", K"MacroName", K"StringMacroName"))::Bool || continue
 
         # Skip quoted identifiers
         # This won't necessarily catch if they are part of a big quoted block,

--- a/src/improper_qualified_accesses.jl
+++ b/src/improper_qualified_accesses.jl
@@ -52,6 +52,9 @@ function analyze_qualified_names(mod::Module, file=pathof(mod);
 end
 
 function process_qualified_row(row, mod)
+    # for JET
+    @assert !isnothing(row.qualified_by)
+    
     isempty(row.qualified_by) && return nothing
     current_mod = mod
     for submod in row.qualified_by

--- a/src/interactive_usage.jl
+++ b/src/interactive_usage.jl
@@ -101,10 +101,11 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                                                                                    file_analysis=file_analysis[file],
                                                                                    allow_internal_imports=false)
 
+            if problematic_imports_for_stale === nothing
+                continue
+            end
             # separate checks for non-stale where we respect the setting for `allow_internal_imports`
-            problematic_imports = if isnothing(problematic_imports_for_stale)
-                nothing
-            elseif allow_internal_imports
+            problematic_imports = if allow_internal_imports
                 filter(row -> !row.internal_import,
                        problematic_imports_for_stale)
             else

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,13 @@
+precompile(print_explicit_imports, (Module,))
+precompile(print_explicit_imports, (Base.TTY, Module, String))
+precompile(main, (Vector{String},))
+
+# These are non-public so I don't want to start throwing if they stop existing,
+# however we do seem to need explicit precompile calls to hit them
+try
+    precompile(Markdown.term, (Base.TTY, Markdown.Code, Int))
+    precompile(Markdown.term, (Base.TTY, Markdown.Paragraph, Int))
+    precompile(Markdown.term, (Base.TTY, Markdown.List, Int))
+catch err
+    @debug "Error in precompiles" err
+end


### PR DESCRIPTION
some of these changes make JET happier, but I think only the precompiles do anything for the actual TTFX, which improves it by ~0.3s, going from 2.3s to 2s on example.jl.