### PR TITLE
Print modules and files wrapped in backticks so that names with `_` don't cause italics

### DIFF
--- a/src/checks.jl
+++ b/src/checks.jl
@@ -41,7 +41,7 @@ function Base.showerror(io::IO, e::QualifiedAccessesFromNonOwnerException)
     for row in e.accesses
         owner = owner_mod_for_printing(row.whichmodule, row.name, row.value)
         println(io,
-                "- `$(row.name)` has owner $(owner) but it was accessed from $(row.accessing_from) at $(row.location)")
+                "- `$(row.name)` has owner `$(owner)` but it was accessed from `$(row.accessing_from)` at $(row.location)")
     end
 end
 
@@ -73,7 +73,7 @@ function Base.showerror(io::IO, e::ExplicitImportsFromNonOwnerException)
             "Module `$(e.mod)` has explicit imports of names from modules other than their owner as determined via `Base.which`:")
     for row in e.bad_imports
         println(io,
-                "- `$(row.name)` has owner $(row.whichmodule) but it was imported from $(row.importing_from) at $(row.location)")
+                "- `$(row.name)` has owner `$(row.whichmodule)` but it was imported from `$(row.importing_from)` at $(row.location)")
     end
 end
 
@@ -89,7 +89,7 @@ function Base.showerror(io::IO, e::NonPublicExplicitImportsException)
             "Module `$(e.mod)` has explicit imports of names from modules in which they are not public (i.e. exported or declared public in Julia 1.11+):")
     for row in e.bad_imports
         println(io,
-                "- `$(row.name)` is not public in $(row.importing_from) but it was imported from $(row.importing_from) at $(row.location)")
+                "- `$(row.name)` is not public in `$(row.importing_from)` but it was imported from `$(row.importing_from)` at $(row.location)")
     end
 end
 
@@ -105,7 +105,7 @@ function Base.showerror(io::IO, e::NonPublicQualifiedAccessException)
             "Module `$(e.mod)` has explicit imports of names from modules in which they are not public (i.e. exported or declared public in Julia 1.11+):")
     for row in e.bad_imports
         println(io,
-                "- `$(row.name)` is not public in $(row.accessing_from) but it was imported from $(row.accessing_from) at $(row.location)")
+                "- `$(row.name)` is not public in `$(row.accessing_from)` but it was imported from `$(row.accessing_from)` at $(row.location)")
     end
 end
 struct StaleImportsException <: Exception

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -41,7 +41,7 @@ function Base.showerror(io::IO, e::QualifiedAccessesFromNonOwnerException)
     for row in e.accesses
         owner = owner_mod_for_printing(row.whichmodule, row.name, row.value)
         println(io,
-                "- `$(row.name)` has owner `$(owner)` but it was accessed from `$(row.accessing_from)` at $(row.location)")
+                "- `$(row.name)` has owner `$(owner)` but it was accessed from `$(row.accessing_from)` at `$(row.location)`")
     end
 end
 
@@ -56,7 +56,7 @@ function Base.showerror(io::IO, e::SelfQualifiedAccessException)
             "Module `$(e.mod)` has self-qualified accesses:")
     for row in e.accesses
         println(io,
-                "- `$(row.name)` was accessed as `$(e.mod).$(row.name)` inside `$(e.mod)` at $(row.location)")
+                "- `$(row.name)` was accessed as `$(e.mod).$(row.name)` inside `$(e.mod)` at `$(row.location)`")
     end
 end
 
@@ -73,7 +73,7 @@ function Base.showerror(io::IO, e::ExplicitImportsFromNonOwnerException)
             "Module `$(e.mod)` has explicit imports of names from modules other than their owner as determined via `Base.which`:")
     for row in e.bad_imports
         println(io,
-                "- `$(row.name)` has owner `$(row.whichmodule)` but it was imported from `$(row.importing_from)` at $(row.location)")
+                "- `$(row.name)` has owner `$(row.whichmodule)` but it was imported from `$(row.importing_from)` at `$(row.location)`")
     end
 end
 
@@ -89,7 +89,7 @@ function Base.showerror(io::IO, e::NonPublicExplicitImportsException)
             "Module `$(e.mod)` has explicit imports of names from modules in which they are not public (i.e. exported or declared public in Julia 1.11+):")
     for row in e.bad_imports
         println(io,
-                "- `$(row.name)` is not public in `$(row.importing_from)` but it was imported from `$(row.importing_from)` at $(row.location)")
+                "- `$(row.name)` is not public in `$(row.importing_from)` but it was imported from `$(row.importing_from)` at `$(row.location)`")
     end
 end
 
@@ -105,7 +105,7 @@ function Base.showerror(io::IO, e::NonPublicQualifiedAccessException)
             "Module `$(e.mod)` has explicit imports of names from modules in which they are not public (i.e. exported or declared public in Julia 1.11+):")
     for row in e.bad_imports
         println(io,
-                "- `$(row.name)` is not public in `$(row.accessing_from)` but it was imported from `$(row.accessing_from)` at $(row.location)")
+                "- `$(row.name)` is not public in `$(row.accessing_from)` but it was imported from `$(row.accessing_from)` at `$(row.location)`")
     end
 end
 struct StaleImportsException <: Exception

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -12,7 +12,7 @@ function Base.showerror(io::IO, e::ImplicitImportsException)
     for row in e.names
         name = row.name
         source = row.source
-        println(io, "* `$name` which is exported by $(source)")
+        println(io, "* `$name` which is exported by `$(source)`")
     end
 end
 
@@ -56,7 +56,7 @@ function Base.showerror(io::IO, e::SelfQualifiedAccessException)
             "Module `$(e.mod)` has self-qualified accesses:")
     for row in e.accesses
         println(io,
-                "- `$(row.name)` was accessed as $(e.mod).$(row.name) inside $(e.mod) at $(row.location)")
+                "- `$(row.name)` was accessed as `$(e.mod).$(row.name)` inside `$(e.mod)` at $(row.location)")
     end
 end
 

--- a/src/interactive_usage.jl
+++ b/src/interactive_usage.jl
@@ -125,7 +125,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                             "$word, $(name_fn(mod)) has stale explicit imports for $plural1 $(length(stale)) unused name$(plural2):")
                     for row in stale
                         println(io,
-                                "- `$(row.name)` is unused but it was imported from `$(row.importing_from)` at $(row.location)")
+                                "- `$(row.name)` is unused but it was imported from `$(row.importing_from)` at `$(row.location)`")
                     end
                 end
                 non_owner = filter(row -> !row.importing_from_submodule_owns_name,
@@ -141,7 +141,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                     for row in non_owner
                         owner = owner_mod_for_printing(row.whichmodule, row.name, row.value)
                         println(io,
-                                "- `$(row.name)` has owner `$(owner)` but it was imported from `$(row.importing_from)` at $(row.location)")
+                                "- `$(row.name)` has owner `$(owner)` but it was imported from `$(row.importing_from)` at `$(row.location)`")
                     end
                 end
                 non_public = report_non_public ?
@@ -160,7 +160,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                             "$word, $(name_fn(mod)) explicitly imports $(length(non_public)) non-public name$(plural):")
                     for row in non_public
                         println(io,
-                                "- `$(row.name)` is not public in `$(row.importing_from)` but it was imported from `$(row.importing_from)` at $(row.location)")
+                                "- `$(row.name)` is not public in `$(row.importing_from)` but it was imported from `$(row.importing_from)` at `$(row.location)`")
                     end
                 end
             end
@@ -183,7 +183,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                         "$word, $(name_fn(mod)) has $(length(self_qualified)) self-qualified access$plural:")
                 for row in self_qualified
                     println(io,
-                            "- `$(row.name)` was accessed as `$(mod).$(row.name)` inside $(mod) at $(row.location)")
+                            "- `$(row.name)` was accessed as `$(mod).$(row.name)` inside $(mod) at `$(row.location)`")
                 end
             end
 
@@ -201,7 +201,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                 for row in non_owner
                     owner = owner_mod_for_printing(row.whichmodule, row.name, row.value)
                     println(io,
-                            "- `$(row.name)` has owner `$(owner)` but it was accessed from `$(row.accessing_from)` at $(row.location)")
+                            "- `$(row.name)` has owner `$(owner)` but it was accessed from `$(row.accessing_from)` at `$(row.location)`")
                 end
             end
 
@@ -222,7 +222,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                         "$word, $(name_fn(mod)) accesses $(length(non_public)) non-public name$(plural):")
                 for row in non_public
                     println(io,
-                            "- `$(row.name)` is not public in `$(row.accessing_from)` but it was accessed via `$(row.accessing_from)` at $(row.location)")
+                            "- `$(row.name)` is not public in `$(row.accessing_from)` but it was accessed via `$(row.accessing_from)` at `$(row.location)`")
                 end
             end
         end

--- a/src/interactive_usage.jl
+++ b/src/interactive_usage.jl
@@ -1,4 +1,3 @@
-
 function print_explicit_imports(mod::Module, file=pathof(mod); kw...)
     return print_explicit_imports(stdout, mod, file; kw...)
 end
@@ -56,7 +55,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                                 warn_stale=nothing,
                                 # internal kwargs
                                 recursive=true,
-                                name_fn=mod -> "module $mod")
+                                name_fn=mod -> "module `$mod`")
     io = IOBuffer()
     if warn_improper_explicit_imports !== nothing && warn_stale !== nothing
         throw(ArgumentError("[print_explicit_imports] Cannot set both `warn_improper_explicit_imports` and `warn_stale`; instead set only `warn_improper_explicit_imports`."))
@@ -126,7 +125,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                             "$word, $(name_fn(mod)) has stale explicit imports for $plural1 $(length(stale)) unused name$(plural2):")
                     for row in stale
                         println(io,
-                                "- `$(row.name)` is unused but it was imported from $(row.importing_from) at $(row.location)")
+                                "- `$(row.name)` is unused but it was imported from `$(row.importing_from)` at $(row.location)")
                     end
                 end
                 non_owner = filter(row -> !row.importing_from_submodule_owns_name,
@@ -142,7 +141,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                     for row in non_owner
                         owner = owner_mod_for_printing(row.whichmodule, row.name, row.value)
                         println(io,
-                                "- `$(row.name)` has owner $(owner) but it was imported from $(row.importing_from) at $(row.location)")
+                                "- `$(row.name)` has owner `$(owner)` but it was imported from `$(row.importing_from)` at $(row.location)")
                     end
                 end
                 non_public = report_non_public ?
@@ -161,7 +160,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                             "$word, $(name_fn(mod)) explicitly imports $(length(non_public)) non-public name$(plural):")
                     for row in non_public
                         println(io,
-                                "- `$(row.name)` is not public in $(row.importing_from) but it was imported from $(row.importing_from) at $(row.location)")
+                                "- `$(row.name)` is not public in `$(row.importing_from)` but it was imported from `$(row.importing_from)` at $(row.location)")
                     end
                 end
             end
@@ -202,7 +201,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                 for row in non_owner
                     owner = owner_mod_for_printing(row.whichmodule, row.name, row.value)
                     println(io,
-                            "- `$(row.name)` has owner $(owner) but it was accessed from $(row.accessing_from) at $(row.location)")
+                            "- `$(row.name)` has owner `$(owner)` but it was accessed from `$(row.accessing_from)` at $(row.location)")
                 end
             end
 
@@ -223,7 +222,7 @@ function print_explicit_imports(final_io::IO, mod::Module, file=pathof(mod);
                         "$word, $(name_fn(mod)) accesses $(length(non_public)) non-public name$(plural):")
                 for row in non_public
                     println(io,
-                            "- `$(row.name)` is not public in $(row.accessing_from) but it was accessed via $(row.accessing_from) at $(row.location)")
+                            "- `$(row.name)` is not public in `$(row.accessing_from)` but it was accessed via `$(row.accessing_from)` at $(row.location)")
                 end
             end
         end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -8,6 +8,6 @@ try
     precompile(Markdown.term, (Base.TTY, Markdown.Code, Int))
     precompile(Markdown.term, (Base.TTY, Markdown.Paragraph, Int))
     precompile(Markdown.term, (Base.TTY, Markdown.List, Int))
-catch err
-    @debug "Error in precompiles" err
+catch ex
+    @debug "Error in precompiles" ex
 end

--- a/test/Test_Mod_Underscores.jl
+++ b/test/Test_Mod_Underscores.jl
@@ -1,0 +1,13 @@
+module Test_Mod_Underscores
+
+using Test # implicit
+using LinearAlgebra: map # non-owner
+using LinearAlgebra: _svd! # non-public
+using LinearAlgebra: svd # unused / stale
+export foo
+
+foo() = @test 42 isa Base.Sys.Number # non-owner access
+bar() = _svd!() + Test_Mod_Underscores.foo() # self access
+qux() = map(Base.__unsafe_string!, 1:2) # non-public access
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -820,7 +820,7 @@ end
                                                          allow_internal_imports=false))
     str = replace(str, r"\s+" => " ")
     @test contains(str, "using .Exporter3: Exporter3 # used at TestModA.jl:")
-    @test contains(str, "is unused but it was imported from `Main.Exporter` at TestModC.jl")
+    @test contains(str, "is unused but it was imported from Main.Exporter at TestModC.jl")
 
     # test `separate_lines=true``
     str = @test_logs sprint(io -> print_explicit_imports(io, TestModA, "TestModA.jl";

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -820,7 +820,7 @@ end
                                                          allow_internal_imports=false))
     str = replace(str, r"\s+" => " ")
     @test contains(str, "using .Exporter3: Exporter3 # used at TestModA.jl:")
-    @test contains(str, "is unused but it was imported from Main.Exporter at TestModC.jl")
+    @test contains(str, "is unused but it was imported from `Main.Exporter` at TestModC.jl")
 
     # test `separate_lines=true``
     str = @test_logs sprint(io -> print_explicit_imports(io, TestModA, "TestModA.jl";
@@ -925,7 +925,7 @@ end
     str = exception_string() do
         return check_all_explicit_imports_are_public(ModImports, "imports.jl")
     end
-    @test contains(str, "`_svd!` is not public in LinearAlgebra but it was imported")
+    @test contains(str, "`_svd!` is not public in `LinearAlgebra` but it was imported")
     @test check_all_explicit_imports_are_public(ModImports, "imports.jl";
                                                 ignore=(:_svd!, :exported_b, :f, :h, :map)) ===
           nothing


### PR DESCRIPTION
Before output looked like e.g.
```
    •  is_eq has owner RAIIR but it was imported from RAIBackIR at src/Quxbaz.jl:44:14
```
<img width="711" alt="Screenshot 2025-04-02 at 14 23 43" src="https://github.com/user-attachments/assets/0ae06615-7a79-424c-a85d-98240a68591d" />

whereas now it looks like
```
    •  is_eq has owner RAI_IR but it was imported from RAI_BackIR at src/Qux_baz:44:14
```
<img width="724" alt="Screenshot 2025-04-02 at 14 23 18" src="https://github.com/user-attachments/assets/377c50e2-48ec-46ed-8792-7af3d8783566" />

-- 

Also fix a precompile warning