### PR TITLE
Add write permissions to CompatHelper action

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed the CompatHelper actions seem to be failing with a permissions issue. I believe this should fix it (see also the template provided [here](https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/.github/workflows/CompatHelper.yml)).