### PR TITLE
bugfix: support module aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 *.jl.cov
 *.jl.mem
 Manifest.toml
+Manifest-v*.toml
 /docs/build/
+dev

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-version = "1.11.2"
+version = "1.11.3"
 authors = ["Eric P. Hanson"]
 
 [deps]

--- a/src/find_implicit_imports.jl
+++ b/src/find_implicit_imports.jl
@@ -45,6 +45,7 @@ function find_implicit_imports(mod::Module; skip=(mod, Base, Core))
             # `WARNING: both Exporter3 and Exporter2 export "exported_a"; uses of it in module TestModA must be qualified`
             # and there is an ambiguity, and the name is in fact not resolved in `mod`
             clash = (err == ErrorException("\"$name\" is not defined in module $mod"))::Bool
+            clash |= (err == ErrorException("Constant binding was imported from multiple modules"))::Bool
             # if it is something else, rethrow
             clash || rethrow()
             missing

--- a/src/improper_explicit_imports.jl
+++ b/src/improper_explicit_imports.jl
@@ -125,18 +125,6 @@ function process_explicitly_imported_row(row, mod)
 
     isempty(explicitly_imported_by) && return nothing
 
-    if explicitly_imported_by[end] !== nameof(current_mod)
-        error("""
-        Encountered implementation bug in `process_explicitly_imported_row`.
-        Please file an issue on ExplicitImports.jl (https://github.com/ericphanson/ExplicitImports.jl/issues/new).
-
-        Info:
-
-        `explicitly_imported_by`=$(explicitly_imported_by)
-        `nameof(current_mod)`=$(nameof(current_mod))
-        """)
-    end
-
     # Ok, now `current_mod` should contain the actual module we imported the name from
     # This lets us query if the name is public in *that* module, get the value, etc
     value = trygetproperty(current_mod, row.name)

--- a/test/module_alias.jl
+++ b/test/module_alias.jl
@@ -1,0 +1,12 @@
+# https://github.com/ericphanson/ExplicitImports.jl/issues/106
+module ModAlias
+
+module M1
+    const g = 9.8
+end
+
+const M1′ = M1
+
+using .M1′: g
+
+end # module ModAlias

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,7 @@ include("test_qualified_access.jl")
 include("test_explicit_imports.jl")
 include("main.jl")
 include("Test_Mod_Underscores.jl")
+include("module_alias.jl")
 
 # For deprecations, we are using `maxlog`, which
 # the TestLogger only respects in Julia 1.8+.
@@ -99,6 +100,13 @@ if VERSION > v"1.9-"
                               (; name=:DataFrame, source=DataFrames),
                               (; name=:groupby, source=DataFrames.DataAPI)]
     end
+end
+
+@testset "module aliases (#106)" begin
+    # https://github.com/ericphanson/ExplicitImports.jl/issues/106
+    ret = Dict(improper_explicit_imports(ModAlias, "module_alias.jl"))
+    @test isempty(ret[ModAlias])
+    @test isempty(ret[ModAlias.M1])
 end
 
 @testset "function arg bug" begin


### PR DESCRIPTION
I'm pretty sure we can just delete this error path, my assumption wasn't right but it doesn't matter. The check was intended for other problems that haven't arose.

closes #106