### PR TITLE
Installing v1.12 doesn't require `nightly` anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,19 +188,18 @@ This can be handy for debugging; if you find that in fact ExplicitImports thinks
 
 ExplicitImports provides an experimental CLI application using the brand-new "apps" functionality from Pkg, available with Julia v1.12.
 
-If you use [juliaup](https://github.com/JuliaLang/juliaup) you can install Julia v1.12 with `juliaup add nightly`, and then run
+If you use [juliaup](https://github.com/JuliaLang/juliaup) you can install Julia v1.12 with `juliaup add 1.12`, and then run
 
 ```sh
-julia +nightly --startup-file=no -e 'using Pkg; Pkg.activate(temp=true); Pkg.Apps.add("ExplicitImports")'
+julia +1.12 --startup-file=no -e 'using Pkg; Pkg.activate(temp=true); Pkg.Apps.add("ExplicitImports")'
 ```
 to install a CLI executable `explicit-imports-jl` to the bin directory in your Julia depot (`~/.julia` by default). You will likely need to add your bin directory to your PATH, e.g.
 
 ```sh
-export PATH="/Users/eph/.julia/bin:$PATH"
+export PATH="${HOME}/.julia/bin:${PATH}"
 ```
 
 which can go in a shell startup script (e.g. `~/.bashrc` or `~/.zshrc`).
-
 
 Then you can run e.g.
 


### PR DESCRIPTION
However maybe it's a bit weird to "tie" the installation instructions to v1.12 specifically?