### PR TITLE
Fix test for Julia nightly Markdown rendering change

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -305,7 +305,7 @@ include("issue_129.jl")
 
         str = sprint(print_explicit_imports, TestQualifiedAccess,
                      "test_qualified_access.jl")
-        @test contains(str, "has 1 self-qualified access:\n\n    •  x was accessed as ")
+        @test contains(str, r"has 1 self-qualified access.*:\n\n\s*•\s+x was accessed as ")
 
         # check_all_qualified_accesses_via_owners
         ex = QualifiedAccessesFromNonOwnerException


### PR DESCRIPTION
my input to Claude Opus 4.5:

> Tests are failing on nightly. To reproduce, delete the top-level Manifest.toml, then use `julia +nightly --project -e '...'` and run the tests (this will take awhile). Then debug.
