### PR TITLE
[~breaking] Fix issue where explicitly imported macros aren't detected as imported

### DIFF
--- a/integration/runtest.jl
+++ b/integration/runtest.jl
@@ -14,7 +14,7 @@ end
     for dir in selected_dirs
         isfile(joinpath(dir, "check.jl")) || continue
         @info "Running integration tests for $(basename(dir))"
-        @test success(`$(Base.julia_cmd()) --project=$dir -e 'using Pkg; Pkg.instantiate()'`)
-        @test success(`$(Base.julia_cmd()) --project=$dir $dir/check.jl`)
+        run(`$(Base.julia_cmd()) --project=$dir -e 'using Pkg; Pkg.instantiate()'`)
+        run(`$(Base.julia_cmd()) --project=$dir $dir/check.jl`)
     end
 end

--- a/src/get_names_used.jl
+++ b/src/get_names_used.jl
@@ -119,7 +119,7 @@ end
 # figure out if `leaf` is part of an import or using statement
 # this seems to trigger for both `X` and `y` in `using X: y`, but that seems alright.
 function analyze_import_type(leaf)
-    kind(leaf) == K"Identifier" || return :not_import
+    kind(leaf) in (K"Identifier", K"MacroName", K"StringMacroName") || return :not_import
     has_parent(leaf) || return :not_import
     is_import = parents_match(leaf, (K"importpath",))
     is_import || return :not_import

--- a/test/issue_97.jl
+++ b/test/issue_97.jl
@@ -1,0 +1,22 @@
+# https://github.com/JuliaTesting/ExplicitImports.jl/issues/97
+module ArgCheck
+
+export @argcheck
+
+macro argcheck(ex)
+    return esc(ex)
+end
+
+end # module
+
+module Issue97
+
+using ..ArgCheck
+using ..ArgCheck: ArgCheck, @argcheck
+
+function positive(x)
+    @argcheck x > 0
+    return x
+end
+
+end # module

--- a/test/issue_97_test.jl
+++ b/test/issue_97_test.jl
@@ -1,0 +1,17 @@
+issue_path = joinpath(@__DIR__, "issue_97.jl")
+include(issue_path)
+
+@testset "Issue #97: macro explicit imports" begin
+    # Issue97 does `using ..ArgCheck` plus `using ..ArgCheck: ArgCheck, @argcheck`.
+    # The macro is explicitly imported, so check_no_implicit_imports should pass.
+    @test check_no_implicit_imports(Issue97, issue_path) === nothing
+    @test check_no_stale_explicit_imports(Issue97, issue_path) === nothing
+
+    analysis = ExplicitImports.get_names_used(issue_path).per_usage_info
+    argcheck_usages = filter(analysis) do nt
+        nt.name == Symbol("@argcheck") && nt.module_path == [:Issue97]
+    end
+
+    @test getfield.(argcheck_usages, :analysis_code) ==
+          [ExplicitImports.IgnoredImportRHS, ExplicitImports.External]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,10 @@ include("issue_140.jl")
         include("issue_111_test.jl")
     end
 
+    @testset "Macro explicit imports (#97)" begin
+        include("issue_97_test.jl")
+    end
+
     @testset "module aliases (#106)" begin
         # https://github.com/JuliaTesting/ExplicitImports.jl/issues/106
         ret = Dict(improper_explicit_imports(ModAlias, "module_alias.jl"))


### PR DESCRIPTION
closes #97 

The added tests fail without the fix:

```julia
julia> include("test/issue_97_test.jl")
Issue #97: macro explicit imports: Error During Test at /Users/eph/ExplicitImports-2/test/issue_97_test.jl:10
  Test threw exception
  Expression: check_no_implicit_imports(Issue97, issue_path) === nothing
  ImplicitImportsException
  Module `Main.Issue97` is relying on the following implicit imports:
  * `@argcheck` which is exported by `Main.ArgCheck`
  
  Stacktrace:
   [1] check_no_implicit_imports(mod::Module, file::String; skip::Tuple{Module, Module, Module}, ignore::Tuple{}, allow_unanalyzable::Tuple{})
     @ ExplicitImports ~/.julia/packages/ExplicitImports/fjM9z/src/checks.jl:233
   [2] check_no_implicit_imports(mod::Module, file::String)
     @ ExplicitImports ~/.julia/packages/ExplicitImports/fjM9z/src/checks.jl:223
   [3] top-level scope
     @ ~/ExplicitImports-2/test/issue_97_test.jl:10
   [4] macro expansion
     @ ~/.julia/juliaup/julia-1.12.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.12/Test/src/Test.jl:1776 [inlined]
   [5] macro expansion
     @ ~/ExplicitImports-2/test/issue_97_test.jl:10 [inlined]
   [6] macro expansion
     @ ~/.julia/juliaup/julia-1.12.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.12/Test/src/Test.jl:677 [inlined]
Issue #97: macro explicit imports: Test Failed at /Users/eph/ExplicitImports-2/test/issue_97_test.jl:18
  Expression: getfield.(argcheck_usages, :analysis_code) == [ExplicitImports.IgnoredImportRHS, ExplicitImports.External]
   Evaluated: ExplicitImports.AnalysisCode[ExplicitImports.External, ExplicitImports.External] == ExplicitImports.AnalysisCode[ExplicitImports.IgnoredImportRHS, ExplicitImports.External]

Stacktrace:
 [1] top-level scope
   @ ~/ExplicitImports-2/test/issue_97_test.jl:10
 [2] macro expansion
   @ ~/.julia/juliaup/julia-1.12.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.12/Test/src/Test.jl:1776 [inlined]
 [3] macro expansion
   @ ~/ExplicitImports-2/test/issue_97_test.jl:18 [inlined]
 [4] macro expansion
   @ ~/.julia/juliaup/julia-1.12.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.12/Test/src/Test.jl:680 [inlined]
Test Summary:                     | Pass  Fail  Error  Total  Time
Issue #97: macro explicit imports |    1     1      1      3  0.1s
RNG of the outermost testset: Random.Xoshiro(0xf709e38b9d3d53d4, 0x75bf66b28f4c0d84, 0x9b0bae133ee651b7, 0x71fd9b1681755d7b, 0x7d71bba10fd6a350)
ERROR: LoadError: Some tests did not pass: 1 passed, 1 failed, 1 errored, 0 broken.
in expression starting at /Users/eph/ExplicitImports-2/test/issue_97_test.jl:7
```