### PR TITLE
Simplify app installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ ExplicitImports provides an experimental CLI application using the brand-new "ap
 If you use [juliaup](https://github.com/JuliaLang/juliaup) you can install Julia v1.12 with `juliaup add 1.12`, and then run
 
 ```sh
-julia +1.12 --startup-file=no -e 'using Pkg; Pkg.activate(temp=true); Pkg.Apps.add("ExplicitImports")'
+julia +1.12 --startup-file=no -e 'using Pkg; Pkg.Apps.add("ExplicitImports")'
 ```
 to install a CLI executable `explicit-imports-jl` to the bin directory in your Julia depot (`~/.julia` by default). You will likely need to add your bin directory to your PATH, e.g.
 


### PR DESCRIPTION
I believe the temporary env was only needed for a bug, namely Pkg taking global env compat constraints into account when resolving the app. I'm not sure if that has been fixed or not but now that we vendor JuliaSyntax we don't have compat issues anyway, so it's not necessary.